### PR TITLE
Add dependency-update flag to include subchart updates

### DIFF
--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -121,6 +121,7 @@ runs:
       run: |
         helm upgrade ${{ inputs.helm_release_name }} .            \
         --install                                                 \
+        --dependency-update                                       \
         --namespace ${{ inputs.app_name }}-${{ inputs.env_name }} \
         ${{ steps.helm_values.outputs.FILES }}                    \
         --set image.tag=${{ inputs.image_tag }}                   \


### PR DESCRIPTION
Including the [--dependency-update](https://helm.sh/docs/helm/helm_upgrade/) flag to add support for sub-charts. 