### PR TITLE
fix(deploy): add missing helm timeout default value unit

### DIFF
--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -49,9 +49,9 @@ inputs:
     description: Helm chart path within infrastructure repository , e.g. testapp1/k8s/testapp1/
     required: true
   helm_timeout:
-    description: Helm chart timeout, defaults to `600`
+    description: Helm chart timeout, defaults to `600s`
     required: false
-    default: "600"
+    default: "600s"
   helm_values:
     description: Helm values specified with '--set' flag value, e.g. "--set 'foo.bar=value'"
     required: false


### PR DESCRIPTION
# Description
[Helm timeout value is a Go duration](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback). Added missing `s` to default value
