### PR TITLE
Add action to push Docker images to GAR.

### DIFF
--- a/docker-push/action.yml
+++ b/docker-push/action.yml
@@ -1,0 +1,41 @@
+name: docker-push
+description: Push a Docker image to GAR.
+
+inputs:
+  local_image:
+    description: "The local Docker image to be pushed."
+    required: true
+  image_repo_host:
+    description: "The host name of the Docker repository to push the image to."
+    required: false
+    default: us-docker.pkg.dev
+  image_repo_path:
+    description: "The path of the Docker repository to push the image to, without the leading slash."
+    required: true
+  image_tag:
+    description: "The Dockaer image tag to be pushed."
+    required: false
+    default: latest
+  workload_identity_pool_project_number:
+    description: Project number of workload identity pool used for OIDC authentication
+    required: true
+  project_id:
+    description: GCP project_id used to construct the service account.
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: projects/${{ inputs.workload_identity_pool_project_number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+        service_account: artifact-writer@${{ inputs.project_id }}.iam.gserviceaccount.com
+    - uses: google-github-actions/setup-gcloud@v1
+    - run: |
+        gcloud --quiet auth configure-docker '${{ inputs.image_repo_host }}'
+        docker tag '${{ inputs.local_image }}' "$TARGET_IMAGE"
+        docker push "$TARGET_IMAGE"
+      env:
+        TARGET_IMAGE: ${{ inputs.image_repo_host }}/${{ inputs.image_repo_path }}:${{ inputs.image_tag }}
+      shell: sh

--- a/docker-push/action.yml
+++ b/docker-push/action.yml
@@ -3,39 +3,47 @@ description: Push a Docker image to GAR.
 
 inputs:
   local_image:
-    description: "The local Docker image to be pushed."
+    description: The local Docker image to be pushed.
     required: true
   image_repo_host:
-    description: "The host name of the Docker repository to push the image to."
+    description: The host name of the Docker repository to push the image to.
     required: false
     default: us-docker.pkg.dev
   image_repo_path:
-    description: "The path of the Docker repository to push the image to, without the leading slash."
+    description: The path of the Docker repository to push the image to, without the leading slash.
     required: true
   image_tag:
-    description: "The Dockaer image tag to be pushed."
+    description: The Dockaer image tag to be pushed.
     required: false
     default: latest
   workload_identity_pool_project_number:
-    description: Project number of workload identity pool used for OIDC authentication
+    description: Project number of workload identity pool used for OIDC authentication.
     required: true
   project_id:
     description: GCP project_id used to construct the service account.
     required: true
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Authenticate to GCP
+      id: auth
       uses: google-github-actions/auth@v1
       with:
-        workload_identity_provider: projects/${{ inputs.workload_identity_pool_project_number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-        service_account: artifact-writer@${{ inputs.project_id }}.iam.gserviceaccount.com
-    - uses: google-github-actions/setup-gcloud@v1
-    - run: |
-        gcloud --quiet auth configure-docker '${{ inputs.image_repo_host }}'
+        workload_identity_provider: "projects/${{ inputs.workload_identity_pool_project_number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
+        service_account: "artifact-writer@${{ inputs.project_id }}.iam.gserviceaccount.com"
+        token_format: access_token
+        create_credentials_file: false
+    - name: Log in to GAR
+      uses: docker/login-action@v3
+      with:
+        registry: "${{ inputs.image_repo_host }}"
+        username: oauth2accesstoken
+        password: "${{ steps.auth.outputs.access_token }}"
+    - name: Tag and push Docker image
+      run: |
         docker tag '${{ inputs.local_image }}' "$TARGET_IMAGE"
         docker push "$TARGET_IMAGE"
       env:
-        TARGET_IMAGE: ${{ inputs.image_repo_host }}/${{ inputs.image_repo_path }}:${{ inputs.image_tag }}
+        TARGET_IMAGE: "${{ inputs.image_repo_host }}/${{ inputs.image_repo_path }}:${{ inputs.image_tag }}"
       shell: sh


### PR DESCRIPTION
This action allows pushing an image to Google Artifact Registry using workload identity federation as authentication.

A successful test run using this action: https://github.com/mozilla-sre-deploy/smarnach-eliot-test/actions/runs/6796281083/job/18476076392

For what it's worth, if the project id is stored in a GitHub Actions secret, this action does not leak it in the logs.