### PR TITLE
deploy: Upgrade Google actions to v1.

### DIFF
--- a/deploy/action.yaml
+++ b/deploy/action.yaml
@@ -91,13 +91,13 @@ runs:
         fi
 
     - name: gcp authentication
-      uses: google-github-actions/auth@v0
+      uses: google-github-actions/auth@v1
       with:
         service_account: ${{ steps.deployment_service_account.outputs.SERVICE_ACCOUNT }}
         workload_identity_provider: projects/${{ inputs.workload_identity_pool_project_number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
 
     - name: get gke credentials
-      uses: google-github-actions/get-gke-credentials@v0
+      uses: google-github-actions/get-gke-credentials@v1
       with:
         cluster_name: ${{ inputs.k8s_cluster_name }}
         location: ${{ inputs.k8s_cluster_location }}


### PR DESCRIPTION
The auth action now emits an error on every run indicating that v0 is no longer maintained. It still works fine, but results in steps marked as failed in the web interface, and there is no reason not to upgrade.

There are no breaking changes in the changelog, and the docker-push action already uses v1 of the auth action, which I confirmed to work. During testing of the docker-push action I also successfully used v1 of the get-gke-credentials action.