### PR TITLE
fix(diff-rendered-charts): added check to exit script if no diff file…

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -127,7 +127,14 @@ jobs:
           script: |
             const fs = require('fs');
             const comment_char_limit = 65536; // GitHub comment character limit
-            const diff = fs.readFileSync('diff.log', 'utf8');
+            const diff_file = 'diff.log';
+
+            if (fs.existsSync(diff_file)) {
+              var diff = fs.readFileSync(diff_file, 'utf8');
+            } else {
+              console.log(diff_file + " not found")
+              return
+            }
 
             function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
               // Adapted from Atlantis SplitComment function


### PR DESCRIPTION
fix(diff-rendered-charts): added check to exit script if no diff file exists. 

If helm changes are only on brand new charts the diff.log will not be created, adding a quick check at the beginning of the script for a diff.log file. 