### PR TITLE
fix(slack/action): Update to latest to get new node runtime

### DIFF
--- a/slack/action.yaml
+++ b/slack/action.yaml
@@ -53,7 +53,7 @@ runs:
   using: composite
   steps:
     - id: slack
-      uses: slackapi/slack-github-action@v1.23.0
+      uses: slackapi/slack-github-action@v1.25.0
       env:
         SLACK_BOT_TOKEN: ${{ inputs.SLACK_BOT_TOKEN }}
         MESSAGE: >-


### PR DESCRIPTION
GitHub is deprecating Nodejs 16 for 20.

https://github.com/slackapi/slack-github-action/releases/tag/v1.25.0

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/