### PR TITLE
fix(diff-rendered-charts): Updated render jobs to check if Chart.yaml…

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -47,7 +47,7 @@ jobs:
           mkdir -p shared/head-charts
           git fetch origin ${{ github.head_ref }}
           git checkout  ${{ github.head_ref }} --
-          if [ -d "${{ matrix.chart }}" ]; then
+          if [ -f "${{ matrix.chart }}/Chart.yaml" ]; then
             helm dependency build "${{ matrix.chart }}"
             values_files="${{ matrix.chart }}"/values-*
             for values_file in $(basename -a $values_files); do
@@ -80,7 +80,7 @@ jobs:
           mkdir -p shared/base-charts
           git fetch origin ${{ github.base_ref }}
           git checkout  ${{ github.base_ref }} --
-          if [ -d "${{ matrix.chart }}" ]; then
+          if [ -f "${{ matrix.chart }}/Chart.yaml" ]; then
             helm dependency build "${{ matrix.chart }}"
             values_files="${{ matrix.chart }}"/values-*
             for values_file in $(basename -a $values_files); do


### PR DESCRIPTION
 Updated render jobs to check if Chart.yaml exists before rendering the charts. Directories can live in the k8s directory without being full helm charts. 