### PR TITLE
fix(diff-rendered-charts): using environment variable for head_ref 

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -9,6 +9,9 @@ name: render and diff helm charts
 on:
   workflow_call:
 
+env:
+  HEAD_REF: ${{ github.head_ref }}
+
 jobs:
   get_changed_helm_charts:
     runs-on: ubuntu-latest
@@ -45,8 +48,8 @@ jobs:
         id: render_head
         run: |
           mkdir -p shared/head-charts
-          git fetch origin ${{ github.head_ref }}
-          git checkout  ${{ github.head_ref }} --
+          git fetch origin "$HEAD_REF"
+          git checkout  "$HEAD_REF" --
           if [ -f "${{ matrix.chart }}/Chart.yaml" ]; then
             helm dependency update "${{ matrix.chart }}"
             values_files="${{ matrix.chart }}"/values-*


### PR DESCRIPTION
using environment variable for head_ref  to avoid command injection issues. 

See: https://securitylab.github.com/research/github-actions-untrusted-input/