### PR TITLE
fix(deployment-status): allow GitHub app keys to be provided as pem files or environment variables

### DIFF
--- a/deployment-status/README.md
+++ b/deployment-status/README.md
@@ -84,4 +84,4 @@ A GitHub app with the permissions to create/modify deployments and/or releases o
 
 - `INSTALLATION_ID` - The installation ID of the GitHub app installed in the target repository
 
-- `PRIVATE_KEY` - The private key of the required GitHub app
+- `PRIVATE_KEY` - The private key of the required GitHub app. This can be an environment variable, or a file mounted with the `.pem` extension. 

--- a/deployment-status/app/main.py
+++ b/deployment-status/app/main.py
@@ -40,7 +40,12 @@ from cryptography.hazmat.backends import default_backend
     required=True,
 )
 def main(key, repo, organization, app_id, install_id):
-    private_pem = key.encode()
+    if key.endswith('.pem'):
+      keyfile = open(key, 'r').read()
+      private_pem = keyfile.encode()
+    else:
+      private_pem = key.encode()
+
     main.private_key = default_backend().load_pem_private_key(private_pem, None)
     main.gh_repo = repo
     main.gh_org = organization


### PR DESCRIPTION
Allow GitHub app keys to be provided as pem files or environment variables. 

The documentation supports a key file being provided, but we are passing in an environment variable when using this in a GitHub action. 

I am adding a quick if statement to read in a file if the key is provided following the GitHub app format.  

