### PR TITLE
fix(docker-push): Disable GitHub's auto-merge feature.

### DIFF
--- a/docker-push/action.yml
+++ b/docker-push/action.yml
@@ -56,6 +56,7 @@ runs:
         gh api "repos/${{ github.repository }}/deployments" \
             -f environment="${{ inputs.deployment_env }}" \
             -f ref="${{ github.ref }}" \
+            -F auto_merge=false \
             -F required_contexts[] \
             -F payload[image_tag]="${{ inputs.image_tag }}"
       env:


### PR DESCRIPTION
The auto-merge feature is opaque and surprising. I think it's meant to be used when deploying feature branches that are potentially behind main, but even then I think it's weird. And it's particularly strange it's enabled by default. It usually doesn't hurt, but let's disable it to avoid surprises.