### PR TITLE
Add input to set color on custom Slack notifs

### DIFF
--- a/slack/action.yaml
+++ b/slack/action.yaml
@@ -35,6 +35,11 @@ inputs:
       required: false
       type: string
       default: ""
+    color:
+      description: Custom color when inputs.type is set to 'custom'
+      required: false
+      type: string
+      default: "#28a745"
     mentions:
       description: Slack users or groups to mention in the message
       required: false
@@ -145,7 +150,7 @@ runs:
             "custom": {
               "attachments": [
                 {
-                  "color": "#28a745",
+                  "color": "${{ inputs.color }}",
                   "fallback": "${{ inputs.app_name }} ${{ inputs.env_name }}: custom",
                   "blocks": [
                     {


### PR DESCRIPTION
It would allow us to show error notifs as red on actions that not deploys, for example:

<img width="777" alt="Screenshot 2024-11-27 at 13 49 56" src="https://github.com/user-attachments/assets/076d1c34-e415-4930-b7e1-2c5d24d351a0">
