### PR TITLE
feat(validate-k8s-manifests): added workflow to validate rendered k8s…

### DIFF
--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -133,7 +133,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const commentHeader = "Validated rendered Kubernetes manifests.";
+            const marker = "<!-- kubeconform-marker -->";
 
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
@@ -143,7 +143,7 @@ jobs:
 
             for (const comment of comments) {
               if (
-                comment.body.startsWith(commentHeader) &&
+                comment.body.includes(marker) &&
                 comment.user.type === "Bot"
               ) {
                 await github.graphql(`
@@ -171,41 +171,44 @@ jobs:
 
             const fullLog = fs.readFileSync('kubeconform.log', 'utf8').trim();
 
-            // Extract the last line for the summary
+            // Summary line
             const lines = fullLog.split('\n');
             const summaryLine = lines.find(line => line.startsWith('Summary:'));
-            const detailOutput = `<details><summary>Show full output</summary>\n\n\`\`\`text\n${fullLog}\n\`\`\`\n</details>`;
 
-            const fullComment = `${summaryLine}\n\n${detailOutput}`;
-
+            const marker = '<!-- kubeconform-marker -->';
             const commentCharLimit = 65536;
 
-            function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
-              if (comment.length <= (maxSize - comStart.length)) {
-                return [comStart + comment];
+            // Build full message wrapped in collapsible section
+            const detailWrapped = `<details><summary>Show full output</summary>\n\n\`\`\`text\n${fullLog}\n\`\`\`\n</details>`;
+
+            function splitComment(content, maxSize, sepEnd, sepStart, comStart) {
+              // Adapted from Atlantis SplitComment function
+              // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
+              if (content.length <= (maxSize - comStart.length)) {
+                return [comStart + content + marker];
               }
 
               const maxWithSep = maxSize - sepEnd.length - sepStart.length;
-              const numComments = Math.ceil(comment.length / maxWithSep);
+              const numComments = Math.ceil(content.length / maxWithSep);
               const comments = [];
 
               for (let i = 0; i < numComments; i++) {
                 const start = i * maxWithSep;
-                const end = Math.min(comment.length, (i + 1) * maxWithSep);
-                let chunk = comment.slice(start, end);
+                const end = Math.min(content.length, (i + 1) * maxWithSep);
+                let chunk = content.slice(start, end);
 
                 if (i < numComments - 1) chunk += sepEnd;
                 if (i > 0) chunk = sepStart + chunk;
                 else chunk = comStart + chunk;
 
-                comments.push(chunk);
+                comments.push(chunk + marker);
               }
 
               return comments;
             }
 
-            const sepEnd = "\n```\n</details>\n\n**Note**: Output continued in next comment.";
-            const sepStart = "Continued from previous comment.\n<details><summary>Show full output</summary>\n\n```text\n";
+            const sepEnd = "\n```\n</details>\n\n**Note:** Continued in next comment.";
+            const sepStart = "Continued from previous comment:\n<details><summary>Show full output</summary>\n\n```text\n";
             const comStart = `${summaryLine}\n\n<details><summary>Show full output</summary>\n\n\`\`\`text\n`;
 
             const comments = splitComment(fullLog, commentCharLimit, sepEnd, sepStart, comStart);

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -129,22 +129,19 @@ jobs:
 
           echo "kubeconform_exit_code=$exit_code" >> $GITHUB_OUTPUT
 
-      - name: post kubeconform validation comment (and minimize old ones)
+      - name: minimize previous kubeconform comments
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const summary = fs.readFileSync('kubeconform.log', 'utf8');
             const commentHeader = "Validated rendered Kubernetes manifests.";
-            const body = `${commentHeader}\n\n\`\`\`text\n${summary}\n\`\`\``;
 
-            const comments = await github.rest.issues.listComments({
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
 
-            for (const comment of comments.data) {
+            for (const comment of comments) {
               if (
                 comment.body.startsWith(commentHeader) &&
                 comment.user.type === "Bot"
@@ -157,7 +154,6 @@ jobs:
                     }) {
                       minimizedComment {
                         isMinimized
-                        minimizedReason
                       }
                     }
                   }
@@ -167,12 +163,53 @@ jobs:
               }
             }
 
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
+      - name: post kubeconform comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const summary = fs.readFileSync('kubeconform.log', 'utf8');
+            const commentHeader = "Validated rendered Kubernetes manifests.";
+            const commentCharLimit = 65536;
+
+            function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
+              if (comment.length <= (maxSize - comStart.length)) {
+                return [comStart + comment];
+              }
+
+              const maxWithSep = maxSize - sepEnd.length - sepStart.length;
+              const numComments = Math.ceil(comment.length / maxWithSep);
+              const comments = [];
+
+              for (let i = 0; i < numComments; i++) {
+                const start = i * maxWithSep;
+                const end = Math.min(comment.length, (i + 1) * maxWithSep);
+                let chunk = comment.slice(start, end);
+
+                if (i < numComments - 1) chunk += sepEnd;
+                if (i > 0) chunk = sepStart + chunk;
+                else chunk = comStart + chunk;
+
+                comments.push(chunk);
+              }
+
+              return comments;
+            }
+
+            const sepEnd = "\n```\n\n**Note**: Output continued in next comment.";
+            const sepStart = "Continued from previous comment.\n\n```text\n";
+            const comStart = `${commentHeader}\n\n\`\`\`text\n`;
+
+            const comments = splitComment(summary, commentCharLimit, sepEnd, sepStart, comStart);
+
+            for (const body of comments) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }
 
       - name: fail workflow if kubeconform validation fails
         run: |

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -102,14 +102,22 @@ jobs:
       - name: validate k8s manifests
         id: validate_k8s_manifests
         run: |
-          set -euo pipefail
-            echo "${{ needs.get_changed_helm_charts.outputs.charts }}" | while read -r chart; do
-              echo "Validating ${chart}..."
+          set -o pipefail
+          exit_code=0
+
+          echo "${{ needs.get_changed_helm_charts.outputs.charts }}" | while read -r chart; do
+            echo "Validating ${chart}..."
+            if [ -d "shared/charts/${chart}" ]; then
               /usr/local/bin/kubeconform \
                 -schema-location default \
                 -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
-                -summary "shared/charts/${chart}"
-            done >> kubeconform.log
+                -summary "shared/charts/${chart}" || exit_code=$?
+            else
+              echo "No rendered manifests found for ${chart}."
+            fi
+          done >> kubeconform.log 2>&1
+
+          echo "kubeconform_exit_code=$exit_code" >> $GITHUB_OUTPUT
 
       - name: post kubeconform validation summary as comment on pull request
         if: needs.get_changed_helm_charts.outputs.charts != ''
@@ -166,3 +174,9 @@ jobs:
                 body: comment
               })
             }
+
+      - name: fail workflow if kubeconform validation fails
+        if: steps.validate_k8s_manifests.outputs.kubeconform_exit_code != '0'
+        run: |
+          echo "Kubeconform failed with exit code ${{ steps.validate_k8s_manifests.outputs.kubeconform_exit_code }}"
+          exit 1

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -111,14 +111,15 @@ jobs:
             echo "Validating ${chart}..."
 
             if [ -d "shared/charts/${chart}" ]; then
-              echo "Cleaning filenames with chartDir prefix: shared/charts/${chart}/k8s/${chart}/"
+              echo "Cleaning filenames with chartDir prefix: shared/charts/${chart}/"
+
               if ! /usr/local/bin/kubeconform \
                   -schema-location default \
                   -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
                   -summary \
                   -output json \
                   "shared/charts/${chart}" \
-                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir; ""))' >> kubeconform.json 2>&1; then
+                   | jq --arg chartDir "shared/charts/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir; ""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi
             else

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -59,7 +59,7 @@ jobs:
             values_files="${{ matrix.chart }}"/values-*
             for values_file in $(basename -a $values_files); do
               env_name=$(basename "$values_file" | sed -E 's/^values-(.+)\.ya?ml$/\1/')
-              helm template "${{ matrix.chart }}" -f "${{ matrix.chart }}/values.yaml" -f "${{ matrix.chart }}/${values_file}" --output-dir "shared/charts/${{ matrix.chart }}/${env_name}"
+              helm template $(basename -a "${{ matrix.chart }}") "${{ matrix.chart }}" -f "${{ matrix.chart }}/values.yaml" -f "${{ matrix.chart }}/${values_file}" --output-dir "shared/charts/${{ matrix.chart }}/${env_name}"
             done
           fi
           echo sanitized_name=$(echo "${{ matrix.chart }}" | sed 's/\//-/g') >> $GITHUB_OUTPUT
@@ -113,17 +113,13 @@ jobs:
               if ! /usr/local/bin/kubeconform \
                   -schema-location default \
                   -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
-                  -summary "shared/charts/${chart}" >> kubeconform.log 2>&1; then
+                  -summary "shared/charts/${chart}" \
+                  -output json \
+                   | jq '.resources |= map(.filename |= sub("^shared/charts/${chart}"; ""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi
-
-              # Remove chart base dir and default release name
-              sed -i \
-                -e "s|shared/charts/${chart}/||g" \
-                -e "s/release-name-//g" \
-                kubeconform.log
             else
-              echo "Warning: Rendered output for ${chart} not found." >> kubeconform.log
+              echo "Warning: Rendered output for ${chart} not found." >> kubeconform.json
             fi
           done
 
@@ -169,16 +165,22 @@ jobs:
           script: |
             const fs = require('fs');
 
-            const fullLog = fs.readFileSync('kubeconform.log', 'utf8').trim();
-
-            // Extract the summary line (or provide a fallback)
-            const lines = fullLog.split('\n');
-            const summaryLine = lines.find(line => line.startsWith('Summary:'));
+            const json = JSON.parse(fs.readFileSync('kubeconform.json', 'utf8'));
 
             const marker = '<!-- kubeconform-marker -->';
             const commentCharLimit = 65536;
 
-            const sepEnd = "\n```\n</details>\n\n**Note:** Continued in next comment.";
+            // Format the summary line
+            const { valid, invalid, errors, skipped } = json.summary;
+            const summaryLine = `Kubeconform Summary: ${valid + invalid + errors + skipped} resources found - Valid: ${valid}, Invalid: ${invalid}, Errors: ${errors}, Skipped: ${skipped}`;
+
+            const errorDetails = json.resources.map(r => {
+              return `${r.filename} - ${r.kind} ${r.name} failed validation: ${r.msg}`;
+            }).join('\n');
+
+            const fullOutput = `<details><summary>Show full output</summary>\n\n\`\`\`text\n${errorDetails}\n\`\`\`\n</details>`;
+
+            const sepEnd = "\n```\n</details>\n\nNote: Continued in next comment.";
             const sepStart = "Continued from previous comment:\n<details><summary>Show full output</summary>\n\n```text\n";
             const comStart = `${summaryLine}\n\n<details><summary>Show full output</summary>\n\n\`\`\`text\n`;
 
@@ -186,7 +188,6 @@ jobs:
               // Adapted from Atlantis SplitComment function
               // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
               if (content.length <= (maxSize - comStart.length)) {
-                // Close the block properly and add marker outside
                 return [`${comStart}${content}\n\`\`\`\n</details>\n${marker}`];
               }
 
@@ -199,24 +200,17 @@ jobs:
                 const end = Math.min(content.length, (i + 1) * maxWithSep);
                 let chunk = content.slice(start, end);
 
-                if (i < numComments - 1) {
-                  chunk += sepEnd;
-                }
+                if (i < numComments - 1) chunk += sepEnd;
+                if (i > 0) chunk = sepStart + chunk;
+                else chunk = comStart + chunk;
 
-                if (i > 0) {
-                  chunk = sepStart + chunk;
-                } else {
-                  chunk = comStart + chunk;
-                }
-
-                // Always close the block and append marker outside the visible text
                 comments.push(`${chunk}\n\`\`\`\n</details>\n${marker}`);
               }
 
               return comments;
             }
 
-            const comments = splitComment(fullLog, commentCharLimit, sepEnd, sepStart, comStart);
+            const comments = splitComment(errorDetails, commentCharLimit, sepEnd, sepStart, comStart);
 
             for (const body of comments) {
               await github.rest.issues.createComment({

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -116,7 +116,7 @@ jobs:
                   -summary \
                   -output json \
                   "shared/charts/${chart}" \
-                   | jq '.resources |= map(.filename |= sub("^shared/charts/${chart}"; ""))' >> kubeconform.json 2>&1; then
+                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir + "/"; ""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi
             else

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -171,21 +171,23 @@ jobs:
 
             const fullLog = fs.readFileSync('kubeconform.log', 'utf8').trim();
 
-            // Summary line
+            // Extract the summary line (or provide a fallback)
             const lines = fullLog.split('\n');
             const summaryLine = lines.find(line => line.startsWith('Summary:'));
 
             const marker = '<!-- kubeconform-marker -->';
             const commentCharLimit = 65536;
 
-            // Build full message wrapped in collapsible section
-            const detailWrapped = `<details><summary>Show full output</summary>\n\n\`\`\`text\n${fullLog}\n\`\`\`\n</details>`;
+            const sepEnd = "\n```\n</details>\n\n**Note:** Continued in next comment.";
+            const sepStart = "Continued from previous comment:\n<details><summary>Show full output</summary>\n\n```text\n";
+            const comStart = `${summaryLine}\n\n<details><summary>Show full output</summary>\n\n\`\`\`text\n`;
 
             function splitComment(content, maxSize, sepEnd, sepStart, comStart) {
               // Adapted from Atlantis SplitComment function
               // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
               if (content.length <= (maxSize - comStart.length)) {
-                return [comStart + content + marker];
+                // Close the block properly and add marker outside
+                return [`${comStart}${content}\n\`\`\`\n</details>\n${marker}`];
               }
 
               const maxWithSep = maxSize - sepEnd.length - sepStart.length;
@@ -197,19 +199,22 @@ jobs:
                 const end = Math.min(content.length, (i + 1) * maxWithSep);
                 let chunk = content.slice(start, end);
 
-                if (i < numComments - 1) chunk += sepEnd;
-                if (i > 0) chunk = sepStart + chunk;
-                else chunk = comStart + chunk;
+                if (i < numComments - 1) {
+                  chunk += sepEnd;
+                }
 
-                comments.push(chunk + marker);
+                if (i > 0) {
+                  chunk = sepStart + chunk;
+                } else {
+                  chunk = comStart + chunk;
+                }
+
+                // Always close the block and append marker outside the visible text
+                comments.push(`${chunk}\n\`\`\`\n</details>\n${marker}`);
               }
 
               return comments;
             }
-
-            const sepEnd = "\n```\n</details>\n\n**Note:** Continued in next comment.";
-            const sepStart = "Continued from previous comment:\n<details><summary>Show full output</summary>\n\n```text\n";
-            const comStart = `${summaryLine}\n\n<details><summary>Show full output</summary>\n\n\`\`\`text\n`;
 
             const comments = splitComment(fullLog, commentCharLimit, sepEnd, sepStart, comStart);
 

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -102,20 +102,30 @@ jobs:
       - name: validate k8s manifests
         id: validate_k8s_manifests
         run: |
-          set -o pipefail
+          set -eo pipefail
+
+          charts="${{ needs.get_changed_helm_charts.outputs.charts }}"
           exit_code=0
 
-          echo "${{ needs.get_changed_helm_charts.outputs.charts }}" | while read -r chart; do
+          for chart in $charts; do
             echo "Validating ${chart}..."
             if [ -d "shared/charts/${chart}" ]; then
-              /usr/local/bin/kubeconform \
-                -schema-location default \
-                -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
-                -summary "shared/charts/${chart}" || exit_code=$?
+              if ! /usr/local/bin/kubeconform \
+                  -schema-location default \
+                  -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
+                  -summary "shared/charts/${chart}" >> kubeconform.log 2>&1; then
+                exit_code=1
+              fi
+
+              # Remove chart base dir and default release name
+              sed -i \
+                -e "s|shared/charts/${chart}/||g" \
+                -e "s/release-name-//g" \
+                kubeconform.log
             else
-              echo "No rendered manifests found for ${chart}."
+              echo "Warning: Rendered output for ${chart} not found." >> kubeconform.log
             fi
-          done >> kubeconform.log 2>&1
+          done
 
           echo "kubeconform_exit_code=$exit_code" >> $GITHUB_OUTPUT
 
@@ -176,7 +186,7 @@ jobs:
             }
 
       - name: fail workflow if kubeconform validation fails
-        if: steps.validate_k8s_manifests.outputs.kubeconform_exit_code != '0'
+#        if: steps.validate_k8s_manifests.outputs.kubeconform_exit_code != '0'
         run: |
           echo "Kubeconform failed with exit code ${{ steps.validate_k8s_manifests.outputs.kubeconform_exit_code }}"
-          exit 1
+          exit 0

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -129,61 +129,52 @@ jobs:
 
           echo "kubeconform_exit_code=$exit_code" >> $GITHUB_OUTPUT
 
-      - name: post kubeconform validation summary as comment on pull request
-        if: needs.get_changed_helm_charts.outputs.charts != ''
+      - name: post kubeconform validation comment (and minimize old ones)
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const comment_char_limit = 65536; // GitHub comment character limit
-            const kubeconform_file = 'kubeconform.log';
+            const summary = fs.readFileSync('kubeconform.log', 'utf8');
+            const commentHeader = "Validated rendered Kubernetes manifests.";
+            const body = `${commentHeader}\n\n\`\`\`text\n${summary}\n\`\`\``;
 
-            if (fs.existsSync(kubeconform_file)) {
-              var summary = fs.readFileSync(kubeconform_file, 'utf8');
-            } else {
-              console.log(kubeconform_file + " not found")
-              return
-            }
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
 
-            function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
-              // Adapted from Atlantis SplitComment function
-              // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
-              if (comment.length <= (comment_char_limit - comStart.length)) {
-                return [comStart + summary]
+            // Minimize previous matching comments from this bot
+            for (const comment of comments.data) {
+              if (
+                comment.body.startsWith(commentHeader) &&
+                comment.user.type === "Bot"
+              ) {
+                await github.rest.graphql(`
+                  mutation MinimizeComment($subjectId: ID!) {
+                    minimizeComment(input: {
+                      subjectId: $subjectId,
+                      classifier: OUTDATED
+                    }) {
+                      minimizedComment {
+                        isMinimized
+                        minimizedReason
+                      }
+                    }
+                  }
+                `, {
+                  subjectId: comment.node_id
+                });
               }
-              maxWithSep = comment_char_limit - sepEnd.length - sepStart.length;
-              var comments = [];
-              var numComments = Math.ceil(comment.length / maxWithSep);
-              for (var i = 0; i < numComments; i++) {
-                var upTo = Math.min(comment.length, (i + 1) * maxWithSep);
-                var portion = comment.slice(i * maxWithSep, upTo);
-                if (i < numComments - 1) {
-                  portion += sepEnd;
-                }
-                if (i > 0) {
-                  portion = sepStart + portion
-                } else {
-                  portion = comStart + portion
-                }
-                comments.push(portion);
-              }
-              return comments;
             }
 
-            var sepEnd = "\n```\n</details>" + "\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment.";
-            var sepStart = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" + "```summary\n";
-            var comStart = "Validated rendered Kubernetes manifests.\n<details><summary>Show Output</summary>\n\n" + "```summary\n";
-
-            comments = splitComment(summary, comment_char_limit, sepEnd, sepStart, comStart);
-
-            for (const comment of comments) {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: comment
-              })
-            }
+            // Post new comment
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
 
       - name: fail workflow if kubeconform validation fails
         run: |

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -116,7 +116,7 @@ jobs:
                   -summary \
                   -output json \
                   "shared/charts/${chart}" \
-                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir + "/"; ""))' >> kubeconform.json 2>&1; then
+                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir ;""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi
             else

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: "shared-head-${{ steps.render_head.outputs.sanitized_name }}"
+          name: "k8s-manifests-${{ steps.render_head.outputs.sanitized_name }}"
           path: "shared"
 
   validate_rendered_helm_chart_manifests:
@@ -95,7 +95,7 @@ jobs:
       - name: download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: shared-*
+          pattern: k8s-manifests-*
           merge-multiple: true
           path: "shared"
 

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -168,8 +168,16 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const summary = fs.readFileSync('kubeconform.log', 'utf8');
-            const commentHeader = "Validated rendered Kubernetes manifests.";
+
+            const fullLog = fs.readFileSync('kubeconform.log', 'utf8').trim();
+
+            // Extract the last line for the summary
+            const lines = fullLog.split('\n');
+            const summaryLine = lines.find(line => line.startsWith('Summary:'));
+            const detailOutput = `<details><summary>Show full output</summary>\n\n\`\`\`text\n${fullLog}\n\`\`\`\n</details>`;
+
+            const fullComment = `${summaryLine}\n\n${detailOutput}`;
+
             const commentCharLimit = 65536;
 
             function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
@@ -196,11 +204,11 @@ jobs:
               return comments;
             }
 
-            const sepEnd = "\n```\n\n**Note**: Output continued in next comment.";
-            const sepStart = "Continued from previous comment.\n\n```text\n";
-            const comStart = `${commentHeader}\n\n\`\`\`text\n`;
+            const sepEnd = "\n```\n</details>\n\n**Note**: Output continued in next comment.";
+            const sepStart = "Continued from previous comment.\n<details><summary>Show full output</summary>\n\n```text\n";
+            const comStart = `${summaryLine}\n\n<details><summary>Show full output</summary>\n\n\`\`\`text\n`;
 
-            const comments = splitComment(summary, commentCharLimit, sepEnd, sepStart, comStart);
+            const comments = splitComment(fullLog, commentCharLimit, sepEnd, sepStart, comStart);
 
             for (const body of comments) {
               await github.rest.issues.createComment({

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -113,8 +113,9 @@ jobs:
               if ! /usr/local/bin/kubeconform \
                   -schema-location default \
                   -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
-                  -summary "shared/charts/${chart}" \
+                  -summary \
                   -output json \
+                  "shared/charts/${chart}" \
                    | jq '.resources |= map(.filename |= sub("^shared/charts/${chart}"; ""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -144,13 +144,12 @@ jobs:
               repo: context.repo.repo
             });
 
-            // Minimize previous matching comments from this bot
             for (const comment of comments.data) {
               if (
                 comment.body.startsWith(commentHeader) &&
                 comment.user.type === "Bot"
               ) {
-                await github.rest.graphql(`
+                await github.graphql(`
                   mutation MinimizeComment($subjectId: ID!) {
                     minimizeComment(input: {
                       subjectId: $subjectId,
@@ -168,7 +167,6 @@ jobs:
               }
             }
 
-            // Post new comment
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -111,8 +111,6 @@ jobs:
             echo "Validating ${chart}..."
 
             if [ -d "shared/charts/${chart}" ]; then
-              echo "Cleaning filenames with chartDir prefix: shared/charts/${chart}/"
-
               if ! /usr/local/bin/kubeconform \
                   -schema-location default \
                   -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
@@ -164,6 +162,7 @@ jobs:
             }
 
       - name: post kubeconform comment
+        if: steps.validate_k8s_manifests.outputs.kubeconform_exit_code != '0'
         uses: actions/github-script@v7
         with:
           script: |
@@ -176,7 +175,7 @@ jobs:
 
             // Format the summary line
             const { valid, invalid, errors, skipped } = json.summary;
-            const summaryLine = `Kubeconform Summary: ${valid + invalid + errors + skipped} resources found - Valid: ${valid}, Invalid: ${invalid}, Errors: ${errors}, Skipped: ${skipped}`;
+            const summaryLine = `Kubernetes Manifest Validation: ${valid + invalid + errors + skipped} resources found - Valid: ${valid}, Invalid: ${invalid}, Errors: ${errors}, Skipped: ${skipped}`;
 
             const errorDetails = json.resources.map(r => {
               return `${r.filename} - ${r.kind} ${r.name} failed validation: ${r.msg}`;

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -109,14 +109,16 @@ jobs:
 
           for chart in $charts; do
             echo "Validating ${chart}..."
+
             if [ -d "shared/charts/${chart}" ]; then
+              echo "Cleaning filenames with chartDir prefix: shared/charts/${chart}/k8s/${chart}/"
               if ! /usr/local/bin/kubeconform \
                   -schema-location default \
                   -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
                   -summary \
                   -output json \
                   "shared/charts/${chart}" \
-                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir ;""))' >> kubeconform.json 2>&1; then
+                   | jq --arg chartDir "shared/charts/${chart}/k8s/${chart}/" '.resources |= map(.filename |= sub("^" + $chartDir; ""))' >> kubeconform.json 2>&1; then
                 exit_code=1
               fi
             else

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -1,0 +1,168 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Reusable workflow to render helm charts and validate their manifests using kubeconform
+# A comment is made on the pull request containing the output
+
+name: render helm charts and validate k8s manifests
+on:
+  workflow_call:
+
+env:
+  HEAD_REF: ${{ github.head_ref }}
+  KUBECONFORM_VERSION: "0.6.7"
+  KUBECONFORM_SHA256: "95f14e87aa28c09d5941f11bd024c1d02fdc0303ccaa23f61cef67bc92619d73"
+  KUBECONFORM_BASE_URL: "https://github.com/yannh/kubeconform/releases/download"
+  KUBECONFORM_SCHEMA_LOCATION: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+
+jobs:
+  get_changed_helm_charts:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_charts: ${{ steps.find_changed_charts.outputs.matrix_changed_charts }}
+      charts: ${{ steps.find_changed_charts.outputs.changed_charts }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+         fetch-depth: '100'
+
+      - name: find changed helm charts
+        id: find_changed_charts
+        run: |
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+          echo matrix_changed_charts=$(git diff --name-only ${{ github.base_ref }}...HEAD -- '**/k8s/**/*.yaml' '**/k8s/**/*.yml' '**/k8s/**/*.tpl' '**/k8s/**/*.tmpl' | cut -d'/' -f1,2,3 | uniq | jq -R 'split("\n")' | jq -s 'flatten(1)') >> $GITHUB_OUTPUT
+          echo changed_charts=$(git diff --name-only ${{ github.base_ref }}...HEAD -- '**/k8s/**/*.yaml' '**/k8s/**/*.yml' '**/k8s/**/*.tpl' '**/k8s/**/*.tmpl' | cut -d'/' -f1,2,3 | uniq) >> $GITHUB_OUTPUT
+
+  render_head_ref_charts:
+    runs-on: ubuntu-latest
+    needs: get_changed_helm_charts
+    strategy:
+      matrix:
+        chart: ${{ fromJSON(needs.get_changed_helm_charts.outputs.matrix_charts) }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: setup helm
+        uses: azure/setup-helm@v4.0.0
+
+      - name: render ${{ matrix.chart }} from head ref
+        id: render_head
+        run: |
+          mkdir -p shared/head-charts
+          git fetch origin "$HEAD_REF"
+          git checkout  "$HEAD_REF" --
+          if [ -f "${{ matrix.chart }}/Chart.yaml" ]; then
+            helm dependency update "${{ matrix.chart }}"
+            values_files="${{ matrix.chart }}"/values-*
+            for values_file in $(basename -a $values_files); do
+              env_name=$(basename "$values_file" | sed -E 's/^values-(.+)\.ya?ml$/\1/')
+              helm template "${{ matrix.chart }}" -f "${{ matrix.chart }}/values.yaml" -f "${{ matrix.chart }}/${values_file}" --output-dir "shared/charts/${{ matrix.chart }}/${env_name}"
+            done
+          fi
+          echo sanitized_name=$(echo "${{ matrix.chart }}" | sed 's/\//-/g') >> $GITHUB_OUTPUT
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "shared-head-${{ steps.render_head.outputs.sanitized_name }}"
+          path: "shared"
+
+  validate_rendered_helm_chart_manifests:
+    runs-on: ubuntu-latest
+    needs:
+      - get_changed_helm_charts
+      - render_head_ref_charts
+    steps:
+      - name: install kubeconform
+        run: |
+          set -euo pipefail
+
+          FILENAME="kubeconform-linux-amd64.tar.gz"
+          DOWNLOAD_URL="${KUBECONFORM_BASE_URL}/v${KUBECONFORM_VERSION}/${FILENAME}"
+
+          echo "Downloading kubeconform from ${DOWNLOAD_URL}..."
+          wget -q "$DOWNLOAD_URL" -O "$FILENAME"
+
+          echo "${KUBECONFORM_SHA256}  $FILENAME" | sha256sum -c -
+
+          echo "Extracting kubeconform..."
+          tar -xzf "$FILENAME"
+          chmod +x kubeconform
+          sudo mv kubeconform /usr/local/bin/kubeconform
+
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: shared-*
+          merge-multiple: true
+          path: "shared"
+
+      - name: validate k8s manifests
+        id: validate_k8s_manifests
+        run: |
+          set -euo pipefail
+            echo "${{ needs.get_changed_helm_charts.outputs.charts }}" | while read -r chart; do
+              echo "Validating ${chart}..."
+              /usr/local/bin/kubeconform \
+                -schema-location default \
+                -schema-location "${KUBECONFORM_SCHEMA_LOCATION}" \
+                -summary "shared/charts/${chart}"
+            done >> kubeconform.log
+
+      - name: post kubeconform validation summary as comment on pull request
+        if: needs.get_changed_helm_charts.outputs.charts != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const comment_char_limit = 65536; // GitHub comment character limit
+            const kubeconform_file = 'kubeconform.log';
+
+            if (fs.existsSync(kubeconform_file)) {
+              var summary = fs.readFileSync(kubeconform_file, 'utf8');
+            } else {
+              console.log(kubeconform_file + " not found")
+              return
+            }
+
+            function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
+              // Adapted from Atlantis SplitComment function
+              // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
+              if (comment.length <= (comment_char_limit - comStart.length)) {
+                return [comStart + summary]
+              }
+              maxWithSep = comment_char_limit - sepEnd.length - sepStart.length;
+              var comments = [];
+              var numComments = Math.ceil(comment.length / maxWithSep);
+              for (var i = 0; i < numComments; i++) {
+                var upTo = Math.min(comment.length, (i + 1) * maxWithSep);
+                var portion = comment.slice(i * maxWithSep, upTo);
+                if (i < numComments - 1) {
+                  portion += sepEnd;
+                }
+                if (i > 0) {
+                  portion = sepStart + portion
+                } else {
+                  portion = comStart + portion
+                }
+                comments.push(portion);
+              }
+              return comments;
+            }
+
+            var sepEnd = "\n```\n</details>" + "\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment.";
+            var sepStart = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" + "```summary\n";
+            var comStart = "Validated rendered Kubernetes manifests.\n<details><summary>Show Output</summary>\n\n" + "```summary\n";
+
+            comments = splitComment(summary, comment_char_limit, sepEnd, sepStart, comStart);
+
+            for (const comment of comments) {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              })
+            }

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -186,7 +186,6 @@ jobs:
             }
 
       - name: fail workflow if kubeconform validation fails
-#        if: steps.validate_k8s_manifests.outputs.kubeconform_exit_code != '0'
         run: |
-          echo "Kubeconform failed with exit code ${{ steps.validate_k8s_manifests.outputs.kubeconform_exit_code }}"
-          exit 0
+          # We want this workflow to fail if kubeconform validation fails, but after posting the comment
+          exit ${{ steps.validate_k8s_manifests.outputs.kubeconform_exit_code }}


### PR DESCRIPTION
This builds upon the work done in the helm-diff workflow to render our helm charts into k8s manifests, but adds a kubeconform validation component. 

I am using a well-known public schema source containing all of the CRD schemas we currently use and a number of others we may use in the future.

It might make more sense to combine this into the helm diff action in the future, or remove kubeconform entirely for a `kubectl` approach. 