### PR TITLE
fix(helmdiff,validate-k8s-manifest): enabled persist-credentials when we check out git repositories, we are using those credentials in future steps

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
          fetch-depth: '100'
-         persist-credentials: false
+         persist-credentials: true # We are using these credentials in later steps
 
       - name: find changed helm charts
         id: find_changed_charts
@@ -44,7 +44,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true # We are using these credentials in later steps
 
       - name: setup helm
         uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f #v4.0.0
@@ -81,7 +81,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          persist-credentials: true # We are using these credentials in later steps
 
       - name: setup helm
         uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f #v4.0.0

--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
          fetch-depth: '100'
-         persist-credentials: false
+         persist-credentials: true # We are using these credentials in later steps
 
       - name: find changed helm charts
         id: find_changed_charts
@@ -49,7 +49,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-         persist-credentials: false
+         persist-credentials: true # We are using these credentials in later steps
 
       - name: setup helm
         uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f #v4.0.0


### PR DESCRIPTION
**CHANGES:** 
* Reverting persist-credentials change 

We are using the git credentials in future steps to checkout different branches and render charts. Setting persist-credentials to true with a comment about it's use