### PR TITLE
Add reusable workflow to build and publish Docker container images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -93,6 +93,7 @@ jobs:
           TMP="$RUNNER_TEMP/preflight.sh"
 
           if [[ -f "$PREFLIGHT_SCRIPT" ]]; then
+            chmod +x "$PREFLIGHT_SCRIPT"
             bash "$PREFLIGHT_SCRIPT"
           else
             printf '%s\n' "$PREFLIGHT_SCRIPT" > "$TMP"
@@ -121,6 +122,7 @@ jobs:
           TMP="$RUNNER_TEMP/verify.sh"
 
           if [[ -f "$VERIFY_SCRIPT" ]]; then
+            chmod +x "$VERIFY_SCRIPT"
             bash "$VERIFY_SCRIPT"
           else
             printf '%s\n' "$VERIFY_SCRIPT" > "$TMP"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.ref }}
           persist-credentials: false
           fetch-tags: true
       - name: Preflight

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,124 @@
+name: Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+      gar_name:
+        required: true
+        type: string
+      project_id:
+        required: true
+        type: string
+      workload_identity_pool_project_number:
+        required: true
+        type: string
+      preflight_script:
+        type: string
+        required: false
+        default: |
+          IMAGE_BUILD_CONTEXT_ABSPATH=$(realpath "$IMAGE_BUILD_CONTEXT")
+
+          printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$IMAGE_BUILD_CONTEXT_ABSPATH/version.json"
+      verify_script:
+        type: string
+        required: false
+        default: ""
+      image_build_context:
+        required: false
+        type: string
+        default: "./"
+      image_tag_metadata:
+        required: false
+        type: string
+      should_tag_ghcr:
+        required: false
+        type: boolean
+        default: false
+      should_tag_latest:
+        required: false
+        type: boolean
+        default: false
+      gar_location:
+        required: false
+        type: string
+        default: "us"
+      service_account_name:
+        required: false
+        type: string
+        default: "artifact-writer"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+          fetch-tags: true
+      - name: Preflight
+        shell: bash
+        env:
+          IMAGE_BUILD_CONTEXT: ${{ inputs.image_build_context }}
+          PREFLIGHT_SCRIPT: ${{ inputs.preflight_script }}
+        if: ${{ inputs.preflight_script != '' }}
+        run: |
+          set -euo pipefail
+          TMP="$RUNNER_TEMP/preflight.sh"
+
+          if [[ -f "$PREFLIGHT_SCRIPT" ]]; then
+            bash "$PREFLIGHT_SCRIPT"
+          else
+            printf '%s\n' "$PREFLIGHT_SCRIPT" > "$TMP"
+            chmod +x "$TMP"
+            bash "$TMP"
+          fi
+      - name: Build and Tag Container Image
+        id: build
+        uses: mozilla/deploy-actions/docker-build@f6e53875d3aff6c2dc4d3499643004376abe0a8a
+        with:
+          image_name: ${{ inputs.image_name }}
+          gar_name: ${{ inputs.gar_name }}
+          project_id: ${{ inputs.project_id }}
+          image_build_context: ${{ inputs.image_build_context }}
+          image_tag_metadata: ${{ inputs.image_tag_metadata }}
+          should_tag_ghcr: ${{ inputs.should_tag_ghcr }}
+          should_tag_latest: ${{ inputs.should_tag_latest }}
+          gar_location: ${{ inputs.gar_location }}
+      - name: Verify Container Image
+        shell: bash
+        if: ${{ inputs.verify_script != '' }}
+        env:
+          VERIFY_SCRIPT: ${{ inputs.verify_script }}
+        run: |
+          set -euo pipefail
+          TMP="$RUNNER_TEMP/verify.sh"
+
+          if [[ -f "$VERIFY_SCRIPT" ]]; then
+            bash "$VERIFY_SCRIPT"
+          else
+            printf '%s\n' "$VERIFY_SCRIPT" > "$TMP"
+            chmod +x "$TMP"
+            bash "$TMP"
+          fi
+      - name: Push Container Image
+        uses: mozilla-it/deploy-actions/docker-push@f6e53875d3aff6c2dc4d3499643004376abe0a8a
+        with:
+          image_tags: ${{ steps.build.outputs.image_tags }}
+          should_authenticate_to_ghcr: ${{ inputs.should_tag_ghcr }}
+          project_id: ${{ inputs.project_id }}
+          gar_location: ${{ inputs.gar_location }}
+          workload_identity_pool_project_number: ${{ inputs.workload_identity_pool_project_number }}
+          service_account_name: ${{ inputs.service_account_name }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
           fetch-tags: true
       - name: Preflight

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.ref }}
           persist-credentials: false
           fetch-tags: true
-      - name: Preflight
+      - name: Run pre-build commands
         shell: bash
         env:
           IMAGE_BUILD_CONTEXT: ${{ inputs.image_build_context }}
@@ -113,7 +113,7 @@ jobs:
           should_tag_ghcr: ${{ inputs.should_tag_ghcr }}
           should_tag_latest: ${{ inputs.should_tag_latest }}
           gar_location: ${{ inputs.gar_location }}
-      - name: Verify Container Image
+      - name: Run post-build commands
         shell: bash
         if: ${{ inputs.postbuild_script != '' }}
         env:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,8 +1,8 @@
-# This reusable workflow encapsulates an end to end workflow for building and
+# This reusable workflow encapsulates an end to end workflow for building and 
 # pushing a container image for a MozCloud Service. It:
-#   - runs a "preflight" script to do things like create a `version.json` file
+#   - runs a `prebuild_script` to prepare the build environment, e.g. create a `version.json` file in the build context
 #   - builds the image
-#   - provides an entrypoint to run verification steps on the image (e.g. load tests)
+#   - provides an entrypoint to run a `postbuild_script`, e.g. run a suite of tests
 #   - pushes the image
 #
 # For details on the workflow inputs passed to docker-build and docker-push, see the 
@@ -29,7 +29,7 @@ on:
         required: false
         default: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
         type: string
-      preflight_script:
+      prebuild_script:
         type: string
         required: false
         default: |
@@ -40,7 +40,7 @@ on:
           "$GITHUB_REF_NAME" \
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
           "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$IMAGE_BUILD_CONTEXT_ABSPATH/version.json"
-      verify_script:
+      postbuild_script:
         type: string
         required: false
         default: ""
@@ -87,17 +87,17 @@ jobs:
         shell: bash
         env:
           IMAGE_BUILD_CONTEXT: ${{ inputs.image_build_context }}
-          PREFLIGHT_SCRIPT: ${{ inputs.preflight_script }}
-        if: ${{ inputs.preflight_script != '' }}
+          PREBUILD_SCRIPT: ${{ inputs.prebuild_script }}
+        if: ${{ inputs.prebuild_script != '' }}
         run: |
           set -euo pipefail
-          TMP="$RUNNER_TEMP/preflight.sh"
+          TMP="$RUNNER_TEMP/prebuild.sh"
 
-          if [[ -f "$PREFLIGHT_SCRIPT" ]]; then
-            chmod +x "$PREFLIGHT_SCRIPT"
-            bash "$PREFLIGHT_SCRIPT"
+          if [[ -f "$PREBUILD_SCRIPT" ]]; then
+            chmod +x "$PREBUILD_SCRIPT"
+            bash "$PREBUILD_SCRIPT"
           else
-            printf '%s\n' "$PREFLIGHT_SCRIPT" > "$TMP"
+            printf '%s\n' "$PREBUILD_SCRIPT" > "$TMP"
             chmod +x "$TMP"
             bash "$TMP"
           fi
@@ -115,18 +115,18 @@ jobs:
           gar_location: ${{ inputs.gar_location }}
       - name: Verify Container Image
         shell: bash
-        if: ${{ inputs.verify_script != '' }}
+        if: ${{ inputs.postbuild_script != '' }}
         env:
-          VERIFY_SCRIPT: ${{ inputs.verify_script }}
+          POSTBUILD_SCRIPT: ${{ inputs.postbuild_script }}
         run: |
           set -euo pipefail
-          TMP="$RUNNER_TEMP/verify.sh"
+          TMP="$RUNNER_TEMP/postbuild.sh"
 
-          if [[ -f "$VERIFY_SCRIPT" ]]; then
-            chmod +x "$VERIFY_SCRIPT"
-            bash "$VERIFY_SCRIPT"
+          if [[ -f "$POSTBUILD_SCRIPT" ]]; then
+            chmod +x "$POSTBUILD_SCRIPT"
+            bash "$POSTBUILD_SCRIPT"
           else
-            printf '%s\n' "$VERIFY_SCRIPT" > "$TMP"
+            printf '%s\n' "$POSTBUILD_SCRIPT" > "$TMP"
             chmod +x "$TMP"
             bash "$TMP"
           fi

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,7 +26,8 @@ on:
         required: true
         type: string
       workload_identity_pool_project_number:
-        required: true
+        required: false
+        default: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
         type: string
       preflight_script:
         type: string

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,3 +1,16 @@
+# This reusable workflow encapsulates an end to end workflow for building and
+# pushing a container image for a MozCloud Service. It:
+#   - runs a "preflight" script to do things like create a `version.json` file
+#   - builds the image
+#   - provides an entrypoint to run verification steps on the image (e.g. load tests)
+#   - pushes the image
+#
+# For details on the workflow inputs passed to docker-build and docker-push, see the 
+# documentation for those actions:
+#  
+# https://github.com/mozilla-it/deploy-actions/tree/main/docker-build
+# https://github.com/mozilla-it/deploy-actions/tree/main/docker-push
+
 name: Docker Build and Push
 
 on:


### PR DESCRIPTION
Adds a reusable, "paved path" workflow for building and publishing Docker container images using the `docker-build` and `docker-push` actions found in this repo.

To test this workflow, I ran it successfully [here](https://github.com/mozilla/cicd-demos/actions/runs/16052637186/job/45298956920).
