### PR TITLE
Fix psa-checker CHART_DIR parsing

### DIFF
--- a/.github/workflows/psa-checker.yml
+++ b/.github/workflows/psa-checker.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           # Loop over each `values-*` dir and check PSS levels
           docker pull $PSA_CHECKER_IMAGE:$PSA_CHECKER_SHA # Pull before run so the output is less messy
-          CHART_NAME=$(echo "$CHART_DIR" | cut -d'/' -f1)
+          CHART_NAME=$(echo "$CHART_DIR" | cut -d'/' -f3)
           cd "shared/charts/$CHART_DIR/"
           for ENV_DIR in */; do
             echo -e "\nChecking $ENV_DIR for chart: $CHART_NAME"


### PR DESCRIPTION
`cut` is currently grabbing the top-level directory name rather than the chart name, causing errors like [this](https://github.com/mozilla/webservices-infra/actions/runs/16030581941/job/45229904873?pr=6352) when the names don't match.

Validated [here](https://github.com/mozilla/webservices-infra/actions/runs/16031579969/job/45233315709?pr=6356)