### PR TITLE
fix(psa-checker): use find rather than assume dir name

### DIFF
--- a/.github/workflows/psa-checker.yml
+++ b/.github/workflows/psa-checker.yml
@@ -69,5 +69,7 @@ jobs:
           cd "shared/charts/$CHART_DIR/"
           for ENV_DIR in */; do
             echo -e "\nChecking $ENV_DIR for chart: $CHART_NAME"
-            cat $ENV_DIR$CHART_NAME/templates/*.yaml | docker run -i $PSA_CHECKER_IMAGE:$PSA_CHECKER_SHA --level "$PSS_LEVEL" -f -
+            cd "$(find $ENV_DIR -type d -name 'templates')"
+            cat *.yaml | docker run -i $PSA_CHECKER_IMAGE:$PSA_CHECKER_SHA --level "$PSS_LEVEL" -f -
+            cd - 
           done


### PR DESCRIPTION
## Description
Use find to get to the `/templates` dir rather than assume the chart name will match the parent directory name.

## Related Tickets & Documents
* MZCLD-785
* Example of failure: https://github.com/mozilla/webservices-infra/actions/runs/16759308665/job/47450186867?pr=6851
* PR where I validated this actually fixes the issue https://github.com/mozilla/webservices-infra/pull/6869