### PR TITLE
feat: add `dockerfile_path` option to build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -37,6 +37,10 @@ on:
         required: false
         type: string
         default: "./"
+      dockerfile_path:
+        required: false
+        type: string
+        default: "./Dockerfile"
       image_tag_metadata:
         required: false
         type: string
@@ -98,6 +102,7 @@ jobs:
           gar_name: ${{ inputs.gar_name }}
           project_id: ${{ inputs.project_id }}
           image_build_context: ${{ inputs.image_build_context }}
+          dockerfile_path: ${{ inputs.dockerfile_path }}
           image_tag_metadata: ${{ inputs.image_tag_metadata }}
           should_tag_ghcr: ${{ inputs.should_tag_ghcr }}
           should_tag_latest: ${{ inputs.should_tag_latest }}

--- a/.github/workflows/docs/build-and-push.md
+++ b/.github/workflows/docs/build-and-push.md
@@ -25,7 +25,8 @@ these inputs.
 | `workload_identity_pool_project_number` | false    | string  | GCP workload identity pool project number. (default: `${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}`) |
 | `prebuild_script`                       | false    | string  | Shell script (either inline or path to script) to run before building the image. (default: *see below)*         |
 | `postbuild_script`                      | false    | string  | Shell script (either inline or path to script) to run after building the image.                                 |
-| `image_build_context`                   | false    | string  | Build context path. (default: `"./"`)                                                                           |
+| `image_build_context`                   | false    | string  | Build context path. Default value is relative to the repository root. (default: `"./"`)                         |
+| `dockerfile_path`                       | false    | string  | Path to Dockerfile. Default value is relative to the repository root. (default: `"./Dockerfile"`)               |
 | `image_tag_metadata`                    | false    | string  | Additional metadata for image tagging.                                                                          |
 | `should_tag_ghcr`                       | false    | boolean | Whether to also tag and push the image to GHCR. (default: `false`)                                              |
 | `should_tag_latest`                     | false    | boolean | Whether to tag the image as `latest`. (default: `false`)                                                        |


### PR DESCRIPTION
## Description
Following up on #79, in this PR, we add the `dockerfile_path` option to the `build-and-push` reusable workflow


## Related Tickets & Documents
* MZCLD-634
