### PR TITLE
chore(docker-push): update image_tags yaml example in docker push action, we need to prune the newline when using it this way

### DIFF
--- a/docker-push/README.md
+++ b/docker-push/README.md
@@ -23,7 +23,7 @@ This GitHub Action is designed to push Docker images to Google Artifact Registry
   uses: mozilla-it/deploy-actions/docker-push@v4
   with:
     # typically provided from another step's output
-    image_tags: |
+    image_tags: |-
       ghcr.io/mozilla/my-repo/my-service:v1.0.0
       us-docker.pkg.dev/moz-fx-tenant-prod/tenant-prod/my-service:v1.0.0
     should_authenticate_to_ghcr: true


### PR DESCRIPTION
## Description

* update image_tags yaml example in docker push action, we need to prune the newline when using it this way

## Related Tickets & Documents
* MZCLD-786
* https://github.com/mozilla/experimenter/actions/runs/16970960080/job/48107508286?pr=13277#step:6:176
