### PR TITLE
feat: Add `docker_build_args` options to build workflow

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -14,6 +14,11 @@ inputs:
   project_id:
     description: GCP project id
     required: true
+  docker_build_args:
+    default: ''
+    description: Optional list of build-time variables https://docs.docker.com/engine/reference/commandline/buildx_build/#build-arg
+    required: false
+    type: string
   image_build_context:
     description: Path to image context for `docker build`
     required: false
@@ -122,6 +127,7 @@ runs:
         # We can't use the intermediate env var trick to appease zizmor in this
         # case. We'll have to rely on docker/build-push-action to handle
         # santizing this input
+        build-args: ${{ inputs.docker_build_args }}
         context: ${{ inputs.image_build_context }} # zizmor: ignore[template-injection]
         file: ${{ inputs.dockerfile_path }}
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Description
Required for this workflow to be used by Relay, it uses git submodules for translations and build arguments for git commit sha1, branch name, and tag name.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* https://github.com/mozilla/fx-private-relay/pull/5809
* https://mozilla-hub.atlassian.net/browse/SVCSE-3549

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
