### PR TITLE
fix(validate-k8s): Skip `$MATRIX_CHART` prefix when passing values override files

### DIFF
--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -65,7 +65,7 @@ jobs:
             values_files=$(find "$MATRIX_CHART" -maxdepth 1 -type f \( -name '*values*.yaml' -o -name '*values*.yml' \) ! \( -name 'values.yaml' -o -name 'values.yml' \))
             for values_file in $values_files; do
               filename=$(basename "$values_file")
-              helm template $(basename -a "$MATRIX_CHART") "$MATRIX_CHART" -f "$MATRIX_CHART/values.yaml" -f "$MATRIX_CHART/${values_file}" --output-dir "shared/charts/$MATRIX_CHART/${filename%.*}"
+              helm template $(basename -a "$MATRIX_CHART") "$MATRIX_CHART" -f "$MATRIX_CHART/values.yaml" -f "${values_file}" --output-dir "shared/charts/$MATRIX_CHART/${filename%.*}"
             done
           fi
           echo sanitized_name=$(echo "$MATRIX_CHART" | sed 's/\//-/g') >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

The filepath returned from `find` will include the chart's containing directory

Example: https://github.com/mozilla/global-platform-admin/actions/runs/17743768851/job/50423920158?pr=4185

```
Error: open argo/k8s/argocd-bootstrap/argo/k8s/argocd-bootstrap/webservices.values.yaml: no such file or directory
```

<details><summary>Details</summary>
<p>

```
bash-5.3$ pwd
/Users/grahamalama/code/github/mozilla-it/global-platform-admin
bash-5.3$ echo $MATRIX_CHART
argo/k8s/argocd-bootstrap
bash-5.3$ find "$MATRIX_CHART" -maxdepth 1 -type f \( -name '*values*.yaml' -o -name '*values*.yml' \) ! \( -name 'values.yaml' -o -name 'values.yml' \)
argo/k8s/argocd-bootstrap/webservices.values.yaml
argo/k8s/argocd-bootstrap/sandbox.values.yaml
argo/k8s/argocd-bootstrap/notifications.values.yaml
argo/k8s/argocd-bootstrap/dataservices.values.yaml
```

</p>
</details> 


## Related Tickets & Documents
* MZCLD-923
