### PR TITLE
Mzcld 983 add build args reusable action

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -14,6 +14,10 @@ on:
       project_id:
         required: true
         type: string
+      docker_build_args:
+        required: false
+        default: ''
+        type: string
       workload_identity_pool_project_number:
         required: false
         default: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
@@ -96,11 +100,12 @@ jobs:
           fi
       - name: Build and Tag Container Image
         id: build
-        uses: mozilla-it/deploy-actions/docker-build@6a12c3dac2fba1f9b66cd0ccbaafb5972093ddd9
+        uses: mozilla-it/deploy-actions/docker-build@8dd1c616131df49ae6ba933eecd115ea8d908311
         with:
           image_name: ${{ inputs.image_name }}
           gar_name: ${{ inputs.gar_name }}
           project_id: ${{ inputs.project_id }}
+          docker_build_args: ${{ inputs.docker_build_args }}
           image_build_context: ${{ inputs.image_build_context }}
           dockerfile_path: ${{ inputs.dockerfile_path }}
           image_tag_metadata: ${{ inputs.image_tag_metadata }}

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -18,7 +18,6 @@ inputs:
     default: ''
     description: Optional list of build-time variables https://docs.docker.com/engine/reference/commandline/buildx_build/#build-arg
     required: false
-    type: string
   image_build_context:
     description: Path to image context for `docker build`
     required: false


### PR DESCRIPTION
## Description

* Support for docker_build_args was added to the docker-build action a few weeks ago, adding that support to the reusable build and push action as well.  
* Removing the input type from the docker-build composite action 

## Related Tickets & Documents
* MZCLD-983

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
