### PR TITLE
feat(build-and-push): Remove permissions block from build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -68,10 +68,6 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Description

These permissions should be inherited from the caller so it can control which permissions it needs specifically. Before this commit, `packages: write` had to be enabled even if the caller wasn't pushing the built image to GHCR.

## Related Tickets & Documents
* MZCLD-845
* closes #70 

I tested this change in https://github.com/mozilla/cicd-demos. On a [new branch](https://github.com/mozilla/cicd-demos/tree/test-permissions), I pointed the workflow at this PR's branch and manually ran it -- [once](https://github.com/mozilla/cicd-demos/actions/runs/17985272400/job/51161756987) with `packages: write` and `should_tag_ghcr: true`, and once [without](https://github.com/mozilla/cicd-demos/actions/runs/17985370843/job/51162096675). Both runs were successful.

