### PR TITLE
fix(workflows): update action references in build-and-push.yml to use new repo

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -101,7 +101,7 @@ jobs:
           fi
       - name: Build and Tag Container Image
         id: build
-        uses: mozilla-it/deploy-actions/docker-build@8d2c17a843ea376c58b4e88e55d1335bafd52bcb #v6.2.0
+        uses: mozilla/deploy-actions/docker-build@8d2c17a843ea376c58b4e88e55d1335bafd52bcb #v6.2.0
         with:
           image_name: ${{ inputs.image_name }}
           gar_name: ${{ inputs.gar_name }}
@@ -132,7 +132,7 @@ jobs:
             bash "$TMP"
           fi
       - name: Push Container Image
-        uses: mozilla-it/deploy-actions/docker-push@8d2c17a843ea376c58b4e88e55d1335bafd52bcb #v6.2.0
+        uses: mozilla/deploy-actions/docker-push@8d2c17a843ea376c58b4e88e55d1335bafd52bcb #v6.2.0
         with:
           image_tags: ${{ steps.build.outputs.image_tags }}
           should_authenticate_to_ghcr: ${{ inputs.should_tag_ghcr }}


### PR DESCRIPTION


## Description
update action references in build-and-push.yml to use new repo

## Related Tickets & Documents
* SVCSE-null
* MZCLD-null

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
