### PR TITLE
feat(validate-k8s-manifests): Update the custome schema location to point at the new crdschema location

### DIFF
--- a/.github/workflows/validate-k8s-manifests.yml
+++ b/.github/workflows/validate-k8s-manifests.yml
@@ -21,7 +21,7 @@ env:
   KUBECONFORM_SHA256: "c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3"
   KUBECONFORM_BASE_URL: "https://github.com/yannh/kubeconform/releases/download"
   KUBECONFORM_SCHEMA_LOCATION: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
-  KUBECONFORM_CUSTOM_SCHEMA_LOCATION: "https://raw.githubusercontent.com/mozilla/mozcloud/main/crdSchemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+  KUBECONFORM_CUSTOM_SCHEMA_LOCATION: "https://storage.googleapis.com/moz-fx-platform-shared-global-mozcloud-tools/crdSchemas/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
 
 jobs:
   get_changed_helm_charts:


### PR DESCRIPTION
## Description
as part of the effort to make `mozilla/mozcloud` private we need to put the crd schemas used by this workflow into another public location.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-3003

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
