### PR TITLE
fix(ci): Dependabot automerge test fixes

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -240,12 +240,19 @@ jobs:
           shopt -s nullglob
 
           for chart in ${CHARTS}; do
+            # When adding or removing a values file the `render_charts` job will only render one side of the chart to be compared
+            # Create the directory to be compared if it doesn't exist so `find` succeeds
+            mkdir -p "shared/base-charts/${chart}" "shared/head-charts/${chart}"
+
             CONFIGS=`find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null basename -a | sort | uniq`
 
             mkdir -p diff/${chart}
 
             for config in ${CONFIGS}; do
               for dir in "shared/base-charts/${chart}/${config}" "shared/head-charts/${chart}/${config}"; do
+                # Create the directory to be compared if it doesn't exist so `find` succeeds
+                mkdir -p "${dir}"
+
                 OUTPUT_FILE="${dir}.yaml"
 
                 touch "$OUTPUT_FILE"

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -275,7 +275,7 @@ jobs:
         run: |
           set -uo pipefail
 
-          CONFTEST_OUTPUT=$(conftest test --no-color --no-fail --strict --update https://raw.githubusercontent.com/mozilla/helm-charts/main/policy/helm-automerge.rego diff)
+          CONFTEST_OUTPUT=$(conftest test --no-color --strict --update https://raw.githubusercontent.com/mozilla/helm-charts/main/policy/helm-automerge.rego diff)
           CONFTEST_EXIT_CODE=$?
           STATUS_DESCRIPTION=$(echo "$CONFTEST_OUTPUT" | tail -1)
 


### PR DESCRIPTION
## Description
This PR has two fixes for the Dependabot automerge test fixes
- Always create directories that may not exist when adding or removing values files
- Allow conftest to exit with an error code ❗ 

The second fix is critical - without it, the automerge workflow for dependabot PRs would always pass 😬 

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-2112
* MZCLD-3001

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
