### PR TITLE
fix(ci): Allow bash script to continue when conftest errors out

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -272,6 +272,7 @@ jobs:
         id: conftest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash {0}
         run: |
           set -uo pipefail
 
@@ -287,7 +288,10 @@ jobs:
             echo "STATUS_STATE=failure" >> "$GITHUB_OUTPUT"
           fi
 
+          exit "${CONFTEST_EXIT_CODE}"
+
       - name: set commit status
+        if: always()
         env:
           STATUS_DESCRIPTION: ${{ steps.conftest.outputs.STATUS_DESCRIPTION }}
           STATUS_STATE: ${{ steps.conftest.outputs.STATUS_STATE }}


### PR DESCRIPTION
## Description
This PR allows the bash script to continue execution when conftest errors out.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-2112

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
