### PR TITLE
fix(ci): Remove concurrency block from reusable workflow to prevent c…

### DIFF
--- a/.github/workflows/git-branch-divergence-check.yaml
+++ b/.github/workflows/git-branch-divergence-check.yaml
@@ -6,10 +6,6 @@ on:
   workflow_call: {}
   pull_request: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   git-branch-divergence-check:
     name: Git Branch Divergence Check


### PR DESCRIPTION
Removed the concurrency block from .github/workflows/git-branch-divergence-check.yaml. Because this workflow is invoked both directly on PRs and as a reusable workflow_call from a caller workflow, both runs computed the same concurrency group, so the callee canceled the caller (or vice versa),  causing a deadlock. 

Dropping the block lets caller and callee coexist.