### PR TITLE
fix(ci): Post recheck status on pull_request so the required context …

### DIFF
--- a/.github/workflows/git-branch-divergence-check.yaml
+++ b/.github/workflows/git-branch-divergence-check.yaml
@@ -35,6 +35,12 @@ jobs:
       # branch protection can't require it. We therefore report the result against the
       # PR head SHA ourselves.
       #
+      # We also post this status on `pull_request` events. The required
+      # `git-branch-divergence-check/recheck` context then lands on every PR head SHA
+      # automatically on each push — otherwise a PR that never receives an
+      # `atlantis plan` comment would have no `recheck` status and stay blocked under
+      # strict required-status rules.
+      #
       # We use the Commit Statuses API deliberately. A check run
       # created with the default GITHUB_TOKEN cannot choose its check suite — GitHub
       # grafts it onto an existing github-actions[bot] suite on that commit. If the PR
@@ -52,7 +58,7 @@ jobs:
       # - https://docs.github.com/en/rest/commits/statuses
       # - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks
       - name: Set pending status on PR head
-        if: github.event_name == 'issue_comment'
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request'
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
@@ -134,7 +140,7 @@ jobs:
       # - https://docs.github.com/en/rest/commits/statuses
       # - https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
       - name: Set final status on PR head
-        if: always() && github.event_name == 'issue_comment'
+        if: always() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
         env:
           DIVERGENCE_OUTCOME: ${{ steps.divergence.outcome }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
@@ -146,9 +152,15 @@ jobs:
           if [ "${DIVERGENCE_OUTCOME}" = "success" ]; then
             STATE=success
             DESCRIPTION="Branch is current with main."
-          else
+          elif [ "${DIVERGENCE_OUTCOME}" = "failure" ]; then
             STATE=failure
             DESCRIPTION="Branch divergence detected; rebase or merge main."
+          else
+            # Run was cancelled (e.g. superseded by a newer push via the caller's
+            # cancel-in-progress concurrency) or skipped. Don't post a spurious
+            # failure; the superseding run reports the authoritative status.
+            echo "Divergence step outcome '${DIVERGENCE_OUTCOME}'; skipping status post."
+            exit 0
           fi
           gh api repos/${{ github.repository }}/statuses/${HEAD_SHA} \
             -f state="${STATE}" \


### PR DESCRIPTION
Every pull_request run now posts the required `git-branch-divergence-check/recheck` commit status onto the current head SHA, so a PR no longer needs a manual atlantis plan comment to satisfy that context. The atlantis plan rerun path is unchanged.

Changes on this PR:

1. "Set pending status" now fires on issue_comment || pull_request.
2. "Set final status" now fires on always() && (issue_comment || pull_request).
3. Cancellation guard — the final-status script now treats success→success, failure→failure, and anything else (cancelled/skipped) as "skip the post and exit 0", so a run superseded by the caller's cancel-in-progress can't strand a spurious failure on the head SHA.
4. Comment added explaining why the status is now posted on pull_request too.

merge_group is intentionally left out — it has no PR number, so the existing exit 1 head-SHA guard still applies.