### PR TITLE
fix(ci): Post recheck status on merge_group 

### DIFF
--- a/.github/workflows/git-branch-divergence-check.yaml
+++ b/.github/workflows/git-branch-divergence-check.yaml
@@ -17,6 +17,7 @@ jobs:
       statuses: write
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+      MERGE_GROUP_SHA: ${{ github.event.merge_group.head_sha }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Resolve PR head SHA
@@ -24,8 +25,11 @@ jobs:
         run: |
           if [ -n "${PR_NUMBER}" ]; then
             HEAD_SHA=$(gh pr view "${PR_NUMBER}" --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)
+          elif [ -n "${MERGE_GROUP_SHA}" ]; then
+            # merge_group event: report against the merge-queue commit GitHub evaluates.
+            HEAD_SHA="${MERGE_GROUP_SHA}"
           else
-            # merge_group or other event without a PR number — fall through to github.ref
+            # No PR number and not a merge_group — fall through to github.ref
             HEAD_SHA=""
           fi
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
@@ -40,6 +44,11 @@ jobs:
       # automatically on each push — otherwise a PR that never receives an
       # `atlantis plan` comment would have no `recheck` status and stay blocked under
       # strict required-status rules.
+      #
+      # We post it on `merge_group` events too, keyed to the merge-queue commit
+      # (`github.event.merge_group.head_sha`). The merge queue evaluates the same
+      # required contexts against that commit, so without this the queue would hang
+      # waiting for a `recheck` status that never arrives.
       #
       # We use the Commit Statuses API deliberately. A check run
       # created with the default GITHUB_TOKEN cannot choose its check suite — GitHub
@@ -58,7 +67,7 @@ jobs:
       # - https://docs.github.com/en/rest/commits/statuses
       # - https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks
       - name: Set pending status on PR head
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request'
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
@@ -140,7 +149,7 @@ jobs:
       # - https://docs.github.com/en/rest/commits/statuses
       # - https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions
       - name: Set final status on PR head
-        if: always() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request')
+        if: always() && (github.event_name == 'issue_comment' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
         env:
           DIVERGENCE_OUTCOME: ${{ steps.divergence.outcome }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}


### PR DESCRIPTION
Changes on this PR - the `git-branch-divergence-check/recheck` commit status is now also posted on `merge_group` events:
- Added MERGE_GROUP_SHA: ${{ github.event.merge_group.head_sha }} to the job env.
- The "Resolve PR head SHA" step now falls back to that merge-group SHA when there's no PR number.
- Both status steps (Set pending / Set final) now fire on merge_group in addition to issue_comment and pull_request.
- Added a comment documenting why.

The ruleset requires `git-branch-divergence-check/recheck` as a status check, and the merge queue validates the same required contexts against its temporary merge-group commit. The workflow's native check run lands there, but nothing was posting the recheck status — verified on PR #1049's merge-group commit 120d7a1e, which had the check run green but no recheck status. So the queue hung "waiting for status to be reported." Posting recheck to github.event.merge_group.head_sha satisfies the requirement and lets the queue proceed.


## Related Tickets & Documents
* MZCLD-2755