### PR TITLE
feat(diff-rendered-charts): compare rendered manifests with dyff

### DIFF
--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -616,10 +616,14 @@ jobs:
             for (const item of changed) {
               chunks.push({ kind: 'text', body: renderSummary(item.entry, item.resources, item.mismatch) });
 
+              // Sort by identity rather than leaving the upstream order in place. dyff emits in
+              // document order and `diff -ruN` in filename order, neither of which is stable or
+              // predictable for a reader looking for a particular resource.
+              const byId = (a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
               const categories = [
-                ['Updated', item.resources.filter((r) => !r.isAddition && !r.isRemoval)],
-                ['Added', item.resources.filter((r) => r.isAddition)],
-                ['Removed', item.resources.filter((r) => r.isRemoval)],
+                ['Updated', item.resources.filter((r) => !r.isAddition && !r.isRemoval).sort(byId)],
+                ['Added', item.resources.filter((r) => r.isAddition).sort(byId)],
+                ['Removed', item.resources.filter((r) => r.isRemoval).sort(byId)],
               ];
 
               for (const [label, resources] of categories) {

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -322,23 +322,43 @@ jobs:
                 addedByGroup.get(group).push(nameOf(id));
               }
 
-              const prefixes = new Map();
+              // Length of the shared trailing run of `-` separated segments. Comparing segments
+              // rather than raw strings is what catches a prefix being *replaced* rather than
+              // merely added: `treeherder-web` versus `treeherder-v2-web` share the tail `web`
+              // but neither name is a suffix of the other.
+              const sharedTail = (a, b) => {
+                let n = 0;
+                while (n < a.length && n < b.length && a[a.length - 1 - n] === b[b.length - 1 - n]) {
+                  n += 1;
+                }
+                return n;
+              };
+
+              const deltas = new Map();
               for (const id of parsed.removed) {
+                const removed = nameOf(id).split('-');
                 for (const addedName of addedByGroup.get(groupOf(id)) || []) {
-                  const removedName = nameOf(id);
-                  let prefix = null;
-                  if (removedName.endsWith(`-${addedName}`)) {
-                    prefix = removedName.slice(0, -(addedName.length + 1));
-                  } else if (addedName.endsWith(`-${removedName}`)) {
-                    prefix = addedName.slice(0, -(removedName.length + 1));
-                  }
-                  if (prefix) prefixes.set(prefix, (prefixes.get(prefix) || 0) + 1);
+                  const added = addedName.split('-');
+                  const shared = sharedTail(removed, added);
+
+                  // Need a shared tail, and the names must not be identical
+                  if (shared === 0) continue;
+                  if (shared === removed.length && shared === added.length) continue;
+
+                  const from = removed.slice(0, removed.length - shared).join('-');
+                  const to = added.slice(0, added.length - shared).join('-');
+                  if (from === to) continue;
+
+                  const delta = `${from || '(none)'} -> ${to || '(none)'}`;
+                  deltas.set(delta, (deltas.get(delta) || 0) + 1);
                 }
               }
 
+              // Requiring the same delta at least twice keeps this tight: two unrelated
+              // resources would have to disagree in exactly the same way to trigger it.
               let best = null;
-              for (const [prefix, count] of prefixes) {
-                if (count >= 2 && (!best || count > best.count)) best = { prefix, count };
+              for (const [delta, count] of deltas) {
+                if (count >= 2 && (!best || count > best.count)) best = { delta, count };
               }
               return best;
             }
@@ -383,13 +403,15 @@ jobs:
 
               if (mismatch) {
                 body += `> **This diff is probably misleading.** ${mismatch.count} resources appear as `;
-                body += `both added and removed, differing only by the name prefix `;
-                body += `\`${mismatch.prefix}-\`. That usually means the two sides were rendered `;
-                body += `under different Helm release names, so resources that actually correspond `;
-                body += `could not be matched up.\n>\n`;
-                body += `> Charts are rendered under their directory name, which is what Argo CD `;
-                body += `uses unless the tenant config sets \`release_name\`. If this chart has such `;
-                body += `an override, treat the added and removed lists as one set of resources, not two.\n\n`;
+                body += `both added and removed, with names differing only in their prefix `;
+                body += `(\`${mismatch.delta}\`). That usually means the two sides were rendered under `;
+                body += `different Helm release names, so resources that actually correspond could not `;
+                body += `be matched up.\n>\n`;
+                body += `> Charts are rendered under their directory name, which is what Argo CD uses `;
+                body += `unless the tenant config sets \`release_name\`. Migrated charts often name `;
+                body += `resources with the release name baked in, to avoid recreating them, so a chart `;
+                body += `with such an override will diff against a prefix it never uses in production. `;
+                body += `Treat the added and removed lists as one set of resources, not two.\n\n`;
               }
 
               body += renderResourceList('Updated', parsed.updated);
@@ -519,8 +541,8 @@ jobs:
                 const mismatch = detectPrefixMismatch(parsed);
                 if (mismatch) {
                   core.warning(
-                    `${entry.chart} / ${entry.config}: ${mismatch.count} resources differ only by ` +
-                      `the name prefix "${mismatch.prefix}-" between the two sides, which suggests ` +
+                    `${entry.chart} / ${entry.config}: ${mismatch.count} resources differ only in ` +
+                      `their name prefix (${mismatch.delta}) between the two sides, which suggests ` +
                       `they were rendered under different Helm release names. The diff for this ` +
                       `config is likely misleading.`,
                   );

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -304,6 +304,45 @@ jobs:
               };
             }
 
+            // A release-name mismatch between the two sides shows up as resources appearing in
+            // both Added and Removed with names differing only by a leading prefix, for example
+            // `release-name-lando-web` removed and `lando-web` added. The workflow renders under
+            // the chart directory name, which is Argo's default, but a chart whose tenant config
+            // sets `release_name` renders under something else in production. Those overrides
+            // live in another repository and are not visible here, so detect the symptom and say
+            // so rather than presenting a wholesale replacement as if it were real.
+            function detectPrefixMismatch(parsed) {
+              const groupOf = (id) => id.split('/').slice(0, -1).join('/'); // apiVersion/Kind
+              const nameOf = (id) => id.split('/').pop();
+
+              const addedByGroup = new Map();
+              for (const id of parsed.added) {
+                const group = groupOf(id);
+                if (!addedByGroup.has(group)) addedByGroup.set(group, []);
+                addedByGroup.get(group).push(nameOf(id));
+              }
+
+              const prefixes = new Map();
+              for (const id of parsed.removed) {
+                for (const addedName of addedByGroup.get(groupOf(id)) || []) {
+                  const removedName = nameOf(id);
+                  let prefix = null;
+                  if (removedName.endsWith(`-${addedName}`)) {
+                    prefix = removedName.slice(0, -(addedName.length + 1));
+                  } else if (addedName.endsWith(`-${removedName}`)) {
+                    prefix = addedName.slice(0, -(removedName.length + 1));
+                  }
+                  if (prefix) prefixes.set(prefix, (prefixes.get(prefix) || 0) + 1);
+                }
+              }
+
+              let best = null;
+              for (const [prefix, count] of prefixes) {
+                if (count >= 2 && (!best || count > best.count)) best = { prefix, count };
+              }
+              return best;
+            }
+
             // Cross-check the classification against the document counts recorded by the diff
             // step: the net change in document count must equal added minus removed. parseDyff
             // keys on dyff's own wording ("one document added"), so if that wording ever changes
@@ -335,12 +374,24 @@ jobs:
               return `**${label} (${ids.length})**\n${lines.join('\n')}\n\n`;
             }
 
-            function renderSummary(entry, parsed) {
+            function renderSummary(entry, parsed, mismatch) {
               let body = `### \`${entry.chart}\` / \`${entry.config}\`\n\n`;
               body += `**${parsed.changeCount} ${parsed.changeCount === 1 ? 'change' : 'changes'}`;
               body += ` across ${parsed.resourceCount}`;
               body += ` ${parsed.resourceCount === 1 ? 'resource' : 'resources'}**`;
               body += ` (${entry.baseDocs} → ${entry.headDocs} documents)\n\n`;
+
+              if (mismatch) {
+                body += `> **This diff is probably misleading.** ${mismatch.count} resources appear as `;
+                body += `both added and removed, differing only by the name prefix `;
+                body += `\`${mismatch.prefix}-\`. That usually means the two sides were rendered `;
+                body += `under different Helm release names, so resources that actually correspond `;
+                body += `could not be matched up.\n>\n`;
+                body += `> Charts are rendered under their directory name, which is what Argo CD `;
+                body += `uses unless the tenant config sets \`release_name\`. If this chart has such `;
+                body += `an override, treat the added and removed lists as one set of resources, not two.\n\n`;
+              }
+
               body += renderResourceList('Updated', parsed.updated);
               body += renderResourceList('Added', parsed.added);
               body += renderResourceList('Removed', parsed.removed);
@@ -464,7 +515,18 @@ jobs:
               } else if (diff.trim().length > 0) {
                 const parsed = parseDyff(diff);
                 checkDocumentCounts(entry, parsed);
-                changed.push({ entry, diff, parsed });
+
+                const mismatch = detectPrefixMismatch(parsed);
+                if (mismatch) {
+                  core.warning(
+                    `${entry.chart} / ${entry.config}: ${mismatch.count} resources differ only by ` +
+                      `the name prefix "${mismatch.prefix}-" between the two sides, which suggests ` +
+                      `they were rendered under different Helm release names. The diff for this ` +
+                      `config is likely misleading.`,
+                  );
+                }
+
+                changed.push({ entry, diff, parsed, mismatch });
               } else {
                 unchanged.push(entry);
               }
@@ -505,7 +567,7 @@ jobs:
             }
 
             for (const item of changed) {
-              chunks.push({ kind: 'text', body: renderSummary(item.entry, item.parsed) });
+              chunks.push({ kind: 'text', body: renderSummary(item.entry, item.parsed, item.mismatch) });
               chunks.push({ kind: 'diff', entry: item.entry, diff: item.diff });
             }
 

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -115,72 +115,366 @@ jobs:
           merge-multiple: true
           path: "shared"
 
-      - name: diff helm charts
-        id: diff_helm_charts
+      # TODO Move this step into a separate action with tool cache support
+      - name: install dyff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for chart in ${CHARTS}; do
-            chart_diff_output=$(diff -r "shared/base-charts/${chart}" "shared/head-charts/${chart}" || true)
-            if [ -n "$chart_diff_output" ]; then
-              echo -e "Changes found in chart: ${chart}\n$(diff -ruN shared/base-charts/${chart} shared/head-charts/${chart})\n" >> diff.log
-            fi
-          done
+          set -euo pipefail
+
+          gh release download v1.12.0 -R homeport/dyff -p "dyff_*_linux_amd64.tar.gz" -O - | tar xzf - dyff
+          mv dyff /usr/local/bin
+
+      - name: diff helm charts
         env:
           CHARTS: ${{ needs.get_changed_helm_charts.outputs.charts }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p diff
+          : > diff/index.tsv
+
+          for chart in ${CHARTS}; do
+            # When adding or removing a values file the `render_charts` job will only render one side of the chart to be compared
+            # Create the directory to be compared if it doesn't exist so `find` succeeds
+            mkdir -p "shared/base-charts/${chart}" "shared/head-charts/${chart}"
+
+            CONFIGS=$(find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null -r basename -a | sort | uniq)
+
+            for config in ${CONFIGS}; do
+              for side in base head; do
+                dir="shared/${side}-charts/${chart}/${config}"
+
+                # Create the directory to be compared if it doesn't exist so `find` succeeds
+                mkdir -p "${dir}"
+
+                # Concatenate every rendered manifest for this config into one multi-document YAML.
+                # dyff keys documents on apiVersion/kind/metadata.name, so the order files land in
+                # here has no bearing on how resources are matched between the two sides. This is
+                # what lets the diff survive templates moving to new paths.
+                MANIFEST="${dir}.yaml"
+
+                : > "$MANIFEST"
+
+                find "$dir" -type f | sort | while read -r file; do
+                  cat "$file" >> "$MANIFEST"
+                  echo "" >> "$MANIFEST"  # ensure newline between files
+                done
+              done
+
+              OUTPUT_FILE="diff/${chart}/${config}.diff"
+              mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+              # `--detect-kubernetes` and `--detect-renames` are dyff defaults; passed explicitly
+              # because they are the whole point of using dyff here
+              if ! dyff between \
+                --output github \
+                --omit-header \
+                --ignore-order-changes \
+                --ignore-whitespace-changes \
+                --detect-kubernetes \
+                --detect-renames \
+                "shared/base-charts/${chart}/${config}.yaml" \
+                "shared/head-charts/${chart}/${config}.yaml" > "$OUTPUT_FILE" 2> "${OUTPUT_FILE}.err"; then
+                # Surface the failure in the comment rather than failing the whole job, so one
+                # unparseable config cannot suppress the diff for every other chart
+                { echo "DYFF_ERROR"; cat "${OUTPUT_FILE}.err"; } > "$OUTPUT_FILE"
+              fi
+
+              BASE_DOCS=$(grep -c '^kind:' "shared/base-charts/${chart}/${config}.yaml" || true)
+              HEAD_DOCS=$(grep -c '^kind:' "shared/head-charts/${chart}/${config}.yaml" || true)
+
+              printf '%s\t%s\t%s\t%s\t%s\n' "$chart" "$config" "$OUTPUT_FILE" "$BASE_DOCS" "$HEAD_DOCS" >> diff/index.tsv
+            done
+          done
 
       - name: post diff as comment on pull request
         if: needs.get_changed_helm_charts.outputs.charts != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const comment_char_limit = 65536; // GitHub comment character limit
-            const diff_file = 'diff.log';
 
-            if (fs.existsSync(diff_file)) {
-              var diff = fs.readFileSync(diff_file, 'utf8');
-            } else {
-              console.log(diff_file + " not found")
-              return
+            const COMMENT_CHAR_LIMIT = 65536; // GitHub comment character limit
+            const MAX_LISTED_RESOURCES = 25;  // per category, before collapsing to a count
+            // Identifies our own comments so superseded ones can be folded away on the next push
+            const MARKER = '<!-- mozilla/deploy-actions:diff-rendered-charts -->';
+            const INDEX_FILE = 'diff/index.tsv';
+
+            // Fold away diffs from previous pushes, the way the Atlantis bot hides stale plans.
+            // They stay in the timeline but collapse, so a long-lived migration PR does not
+            // accumulate pages of dead output.
+            async function hideSupersededComments() {
+              const existing = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+
+              for (const comment of existing.filter((c) => (c.body || '').includes(MARKER))) {
+                try {
+                  await github.graphql(
+                    `mutation($id: ID!) {
+                       minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                         clientMutationId
+                       }
+                     }`,
+                    { id: comment.node_id },
+                  );
+                } catch (error) {
+                  core.warning(`Could not minimize comment ${comment.id}: ${error.message}`);
+                }
+              }
             }
 
-            function splitComment(comment, maxSize, sepEnd, sepStart, comStart) {
-              // Adapted from Atlantis SplitComment function
-              // https://github.com/runatlantis/atlantis/blob/main/server/events/vcs/common/common.go#L18
-              if (comment.length <= (comment_char_limit - comStart.length)) {
-                return [comStart + diff]
-              }
-              maxWithSep = comment_char_limit - sepEnd.length - sepStart.length;
-              var comments = [];
-              var numComments = Math.ceil(comment.length / maxWithSep);
-              for (var i = 0; i < numComments; i++) {
-                var upTo = Math.min(comment.length, (i + 1) * maxWithSep);
-                var portion = comment.slice(i * maxWithSep, upTo);
-                if (i < numComments - 1) {
-                  portion += sepEnd;
+            // dyff's github output is a sequence of blocks:
+            //
+            //   @@ <path> @@
+            //   # <apiVersion>/<Kind>/<name>
+            //   ! <description of the change>
+            //   +/- <values>
+            //
+            // A path of `(root level)` paired with a document added/removed description means the
+            // resource as a whole appeared or disappeared; anything else is a field-level change.
+            function parseDyff(text) {
+              const resources = new Map();
+              let changeCount = 0;
+              let currentPath = null;
+              let currentResource = null;
+
+              for (const line of text.split('\n')) {
+                const pathMatch = line.match(/^@@ (.*) @@$/);
+                const resourceMatch = line.match(/^# (.+)$/);
+                const detailMatch = line.match(/^! (.+)$/);
+
+                if (pathMatch) {
+                  currentPath = pathMatch[1];
+                  currentResource = null;
+                  changeCount += 1;
+                } else if (resourceMatch && currentPath !== null) {
+                  currentResource = resourceMatch[1];
+                  if (!resources.has(currentResource)) {
+                    resources.set(currentResource, { added: false, removed: false });
+                  }
+                } else if (detailMatch && currentResource !== null) {
+                  const isRootLevel = currentPath === '(root level)';
+                  if (isRootLevel && /one document added/.test(detailMatch[1])) {
+                    resources.get(currentResource).added = true;
+                  }
+                  if (isRootLevel && /one document removed/.test(detailMatch[1])) {
+                    resources.get(currentResource).removed = true;
+                  }
                 }
-                if (i > 0) {
-                  portion = sepStart + portion
-                } else {
-                  portion = comStart + portion
-                }
-                comments.push(portion);
               }
+
+              const added = [];
+              const removed = [];
+              const updated = [];
+              for (const [id, flags] of resources) {
+                if (flags.added) added.push(id);
+                else if (flags.removed) removed.push(id);
+                else updated.push(id);
+              }
+
+              return {
+                changeCount,
+                resourceCount: resources.size,
+                added: added.sort(),
+                removed: removed.sort(),
+                updated: updated.sort(),
+              };
+            }
+
+            // Cross-check the classification against the document counts recorded by the diff
+            // step: the net change in document count must equal added minus removed. parseDyff
+            // keys on dyff's own wording ("one document added"), so if that wording ever changes
+            // every resource would quietly fall into Updated and the summary would mislead while
+            // still looking plausible. This turns that silent drift into a warning.
+            function checkDocumentCounts(entry, parsed) {
+              const recorded = Number(entry.headDocs) - Number(entry.baseDocs);
+              const classified = parsed.added.length - parsed.removed.length;
+
+              if (Number.isFinite(recorded) && recorded !== classified) {
+                core.warning(
+                  `${entry.chart} / ${entry.config}: rendered document count changed by ` +
+                    `${recorded}, but ${parsed.added.length} added and ${parsed.removed.length} ` +
+                    `removed account for ${classified}. The added/removed/updated summary may be ` +
+                    `inaccurate; the diff itself is unaffected.`,
+                );
+              }
+            }
+
+            function renderResourceList(label, ids) {
+              if (ids.length === 0) return '';
+
+              const shown = ids.slice(0, MAX_LISTED_RESOURCES);
+              const lines = shown.map((id) => `- \`${id}\``);
+              if (ids.length > shown.length) {
+                lines.push(`- ...and ${ids.length - shown.length} more`);
+              }
+
+              return `**${label} (${ids.length})**\n${lines.join('\n')}\n\n`;
+            }
+
+            function renderSummary(entry, parsed) {
+              let body = `### \`${entry.chart}\` / \`${entry.config}\`\n\n`;
+              body += `**${parsed.changeCount} ${parsed.changeCount === 1 ? 'change' : 'changes'}`;
+              body += ` across ${parsed.resourceCount}`;
+              body += ` ${parsed.resourceCount === 1 ? 'resource' : 'resources'}**`;
+              body += ` (${entry.baseDocs} → ${entry.headDocs} documents)\n\n`;
+              body += renderResourceList('Updated', parsed.updated);
+              body += renderResourceList('Added', parsed.added);
+              body += renderResourceList('Removed', parsed.removed);
+              return body;
+            }
+
+            function renderDiffBlock(entry, diff) {
+              return [
+                `<details><summary>Show full diff for <code>${entry.chart}</code> / <code>${entry.config}</code></summary>`,
+                '',
+                '```diff',
+                diff.trimEnd(),
+                '```',
+                '</details>',
+                '',
+              ].join('\n');
+            }
+
+            // Pack pre-rendered chunks into as few comments as possible, splitting any single
+            // chunk that cannot fit on its own.
+            function packComments(header, chunks) {
+              const continued = 'Continued from previous comment.\n\n';
+              const comments = [];
+              let current = header;
+
+              const flush = () => {
+                if (current.trim().length > 0) comments.push(current);
+                current = continued;
+              };
+
+              for (const chunk of chunks) {
+                if (current.length + chunk.length <= COMMENT_CHAR_LIMIT) {
+                  current += chunk;
+                  continue;
+                }
+
+                flush();
+
+                if (chunk.length + continued.length <= COMMENT_CHAR_LIMIT) {
+                  current += chunk;
+                  continue;
+                }
+
+                // Chunk is too large even alone. Split it on line boundaries so the fenced
+                // block stays coherent, reopening the fence in each continuation.
+                const notice = '\n```\n\n**Note**: output exceeds the maximum comment size, continued in the next comment.';
+                const reopen = continued + '```diff\n';
+                const budget = COMMENT_CHAR_LIMIT - reopen.length - notice.length;
+
+                let buffer = '';
+                for (const line of chunk.split('\n')) {
+                  if (buffer.length + line.length + 1 > budget) {
+                    comments.push(current + buffer + notice);
+                    current = reopen;
+                    buffer = '';
+                  }
+                  buffer += line + '\n';
+                }
+                current += buffer;
+              }
+
+              flush();
               return comments;
             }
 
-            var sepEnd = "\n```\n</details>" + "\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment.";
-            var sepStart = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" + "```diff\n";
-            var comStart = "Changes found in Helm charts.\n<details><summary>Show Output</summary>\n\n" + "```diff\n";
+            if (!fs.existsSync(INDEX_FILE)) {
+              console.log(`${INDEX_FILE} not found, nothing to report`);
+              return;
+            }
 
-            comments = splitComment(diff, comment_char_limit, sepEnd, sepStart, comStart);
+            const entries = fs
+              .readFileSync(INDEX_FILE, 'utf8')
+              .split('\n')
+              .filter((line) => line.trim().length > 0)
+              .map((line) => {
+                const [chart, config, diffPath, baseDocs, headDocs] = line.split('\t');
+                return { chart, config, diffPath, baseDocs, headDocs };
+              });
 
-            for (const comment of comments) {
+            const changed = [];
+            const failed = [];
+            const unchanged = [];
+
+            for (const entry of entries) {
+              const diff = fs.existsSync(entry.diffPath)
+                ? fs.readFileSync(entry.diffPath, 'utf8')
+                : '';
+
+              if (diff.startsWith('DYFF_ERROR')) {
+                failed.push({ entry, message: diff.replace(/^DYFF_ERROR\n?/, '') });
+              } else if (diff.trim().length > 0) {
+                const parsed = parseDyff(diff);
+                checkDocumentCounts(entry, parsed);
+                changed.push({ entry, diff, parsed });
+              } else {
+                unchanged.push(entry);
+              }
+            }
+
+            await hideSupersededComments();
+
+            if (changed.length === 0 && failed.length === 0) {
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: comment
-              })
+                body: `${MARKER}\n## Helm chart diff\n\nNo changes to the rendered Kubernetes manifests.`,
+              });
+              return;
+            }
+
+            let header = `${MARKER}\n## Helm chart diff\n\n`;
+            header += 'Rendered manifests compared by resource identity (`apiVersion`, `kind`, `metadata.name`), ';
+            header += 'so resources are matched even when templates move to new paths.\n\n';
+
+            // Call out configs that rendered identically. On a migration PR a no-op config is
+            // the desired outcome, so its absence from the diff should not be left implicit.
+            if (unchanged.length > 0) {
+              const listed = unchanged.map((e) => `\`${e.chart}\` / \`${e.config}\``).join(', ');
+              header += `No changes to the rendered manifests for ${listed}.\n\n`;
+            }
+
+            const chunks = [];
+
+            for (const { entry, message } of failed) {
+              chunks.push(
+                `### \`${entry.chart}\` / \`${entry.config}\`\n\n` +
+                  `Could not produce a diff for this config.\n\n\`\`\`\n${message.trim()}\n\`\`\`\n\n`,
+              );
+            }
+
+            for (const item of changed) {
+              chunks.push(renderSummary(item.entry, item.parsed));
+              chunks.push(renderDiffBlock(item.entry, item.diff));
+            }
+
+            for (const body of packComments(header, chunks)) {
+              // Backstop: packComments keeps bodies under the limit, but never let an
+              // oversized body be rejected by the API without saying so out loud
+              let safe = body;
+              if (safe.length > COMMENT_CHAR_LIMIT) {
+                const truncated = '\n\n**Note**: output truncated to fit the maximum comment size.';
+                safe = safe.slice(0, COMMENT_CHAR_LIMIT - truncated.length) + truncated;
+                core.warning(`Comment body exceeded ${COMMENT_CHAR_LIMIT} characters and was truncated`);
+              }
+
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: safe,
+              });
             }
 
   evaulate_helm_chart_automerge:

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -107,6 +107,20 @@ jobs:
                   -f "${MATRIX_CHART}/${values_file}" \
                   --output-dir "$render_path"
               fi
+
+              # Concatenate this config's rendered manifests into one multi-document YAML,
+              # written beside the render directory rather than inside it. Both the diff and the
+              # automerge evaluation consume this, so building it once here means they cannot
+              # drift apart and the work is not repeated. Ordering does not matter: both
+              # consumers match documents on apiVersion/kind/metadata.name.
+              manifest="shared/${MATRIX_REF_NAME}-charts/${MATRIX_CHART}/${output_name}.yaml"
+
+              : > "$manifest"
+
+              find "$render_path" -type f | sort | while read -r rendered; do
+                cat "$rendered" >> "$manifest"
+                echo "" >> "$manifest"  # ensure newline between files
+              done
            done
           fi
           echo sanitized_name=$(echo "${MATRIX_CHART}" | sed 's/\//-/g') >> $GITHUB_OUTPUT
@@ -153,31 +167,20 @@ jobs:
           : > diff/index.tsv
 
           for chart in ${CHARTS}; do
-            # When adding or removing a values file the `render_charts` job will only render one side of the chart to be compared
-            # Create the directory to be compared if it doesn't exist so `find` succeeds
             mkdir -p "shared/base-charts/${chart}" "shared/head-charts/${chart}"
 
-            CONFIGS=$(find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null -r basename -a | sort | uniq)
+            # The `render_charts` job already concatenated each config into a single
+            # multi-document YAML beside its render directory, so enumerate those.
+            # `-exec basename` rather than `xargs` so that a chart which rendered nothing
+            # yields an empty list instead of invoking basename with no operands.
+            CONFIGS=$(find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type f -name '*.yaml' -exec basename {} .yaml \; | sort | uniq)
 
             for config in ${CONFIGS}; do
+              # When a values file is added or removed only one side renders it, so stand in an
+              # empty manifest for the missing side rather than skipping the config
               for side in base head; do
-                dir="shared/${side}-charts/${chart}/${config}"
-
-                # Create the directory to be compared if it doesn't exist so `find` succeeds
-                mkdir -p "${dir}"
-
-                # Concatenate every rendered manifest for this config into one multi-document YAML.
-                # dyff keys documents on apiVersion/kind/metadata.name, so the order files land in
-                # here has no bearing on how resources are matched between the two sides. This is
-                # what lets the diff survive templates moving to new paths.
-                MANIFEST="${dir}.yaml"
-
-                : > "$MANIFEST"
-
-                find "$dir" -type f | sort | while read -r file; do
-                  cat "$file" >> "$MANIFEST"
-                  echo "" >> "$MANIFEST"  # ensure newline between files
-                done
+                MANIFEST="shared/${side}-charts/${chart}/${config}.yaml"
+                [ -f "$MANIFEST" ] || : > "$MANIFEST"
               done
 
               OUTPUT_FILE="diff/${chart}/${config}.diff"
@@ -523,6 +526,19 @@ jobs:
                 return { chart, config, diffPath, baseDocs, headDocs };
               });
 
+            // A chart was detected as changed but nothing rendered for it, so there is nothing to
+            // compare. Do not fall through to the "no changes" message below: that would claim the
+            // rendered manifests are identical when in truth none were produced. Usually means the
+            // chart has no per-environment values files, or a changed path is not a chart root.
+            if (entries.length === 0) {
+              core.warning(
+                'No rendered manifests were found for the changed charts, so no diff could be ' +
+                  'produced. Check whether the changed paths are chart roots with per-environment ' +
+                  'values files.',
+              );
+              return;
+            }
+
             const changed = [];
             const failed = [];
             const unchanged = [];
@@ -665,31 +681,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          shopt -s nullglob
-
           for chart in ${CHARTS}; do
-            # When adding or removing a values file the `render_charts` job will only render one side of the chart to be compared
-            # Create the directory to be compared if it doesn't exist so `find` succeeds
             mkdir -p "shared/base-charts/${chart}" "shared/head-charts/${chart}"
 
-            CONFIGS=`find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type d -print0 | xargs --null basename -a | sort | uniq`
+            # The `render_charts` job already concatenated each config into a single
+            # multi-document YAML beside its render directory, so enumerate those.
+            # `-exec basename` rather than `xargs` so that a chart which rendered nothing
+            # yields an empty list instead of invoking basename with no operands, which GNU
+            # xargs would do and which fails the step under `set -euo pipefail`.
+            CONFIGS=$(find "shared/base-charts/${chart}" "shared/head-charts/${chart}" -mindepth 1 -maxdepth 1 -type f -name '*.yaml' -exec basename {} .yaml \; | sort | uniq)
 
             mkdir -p diff/${chart}
 
             for config in ${CONFIGS}; do
-              for dir in "shared/base-charts/${chart}/${config}" "shared/head-charts/${chart}/${config}"; do
-                # Create the directory to be compared if it doesn't exist so `find` succeeds
-                mkdir -p "${dir}"
-
-                OUTPUT_FILE="${dir}.yaml"
-
-                touch "$OUTPUT_FILE"
-
-                # Recursively find and concatenate all files
-                find "$dir" -type f | sort | while read -r file; do
-                  cat "$file" >> "$OUTPUT_FILE"
-                  echo "" >> "$OUTPUT_FILE"  # ensure newline between files
-                done
+              # When a values file is added or removed only one side renders it, so stand in an
+              # empty manifest for the missing side rather than skipping the config
+              for side in base head; do
+                MANIFEST="shared/${side}-charts/${chart}/${config}.yaml"
+                [ -f "$MANIFEST" ] || : > "$MANIFEST"
               done
 
               diffnest --format json-patch "shared/base-charts/${chart}/${config}.yaml" "shared/head-charts/${chart}/${config}.yaml" > "diff/${chart}/${config}.json" || true

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -344,59 +344,89 @@ jobs:
               return body;
             }
 
-            function renderDiffBlock(entry, diff) {
-              return [
-                `<details><summary>Show full diff for <code>${entry.chart}</code> / <code>${entry.config}</code></summary>`,
-                '',
-                '```diff',
-                diff.trimEnd(),
-                '```',
-                '</details>',
-                '',
-              ].join('\n');
+            // Render one slice of a diff, wrapped so that every comment is independently valid:
+            // its own <details> opened and closed, and its own fence opened and closed. An
+            // earlier version reopened only the fence in continuations, which left one comment
+            // with an unclosed <details> and the next with an orphan </details> rendered fully
+            // expanded.
+            function renderDiffPart(entry, body, isContinuation, isFinal) {
+              const suffix = isContinuation ? ' (continued)' : '';
+              let out = `<details><summary>Show full diff for <code>${entry.chart}</code> / <code>${entry.config}</code>${suffix}</summary>\n\n`;
+              out += '```diff\n' + body.replace(/\n+$/, '') + '\n```\n</details>\n\n';
+              if (!isFinal) {
+                out += '**Note**: output exceeds the maximum comment size, continued in the next comment.\n\n';
+              }
+              return out;
             }
 
-            // Pack pre-rendered chunks into as few comments as possible, splitting any single
-            // chunk that cannot fit on its own.
+            // Pack chunks into as few comments as possible. Diff chunks are sliced on line
+            // boundaries when they cannot fit, each slice individually wrapped. Every comment
+            // begins with MARKER so that all of them, not just the first, are found and folded
+            // away on the next push.
             function packComments(header, chunks) {
-              const continued = 'Continued from previous comment.\n\n';
+              const continued = `${MARKER}\nContinued from previous comment.\n\n`;
               const comments = [];
               let current = header;
+              let hasContent = false;
+
+              const append = (text) => {
+                current += text;
+                hasContent = true;
+              };
 
               const flush = () => {
-                if (current.trim().length > 0) comments.push(current);
+                if (hasContent) comments.push(current);
                 current = continued;
+                hasContent = false;
               };
 
               for (const chunk of chunks) {
-                if (current.length + chunk.length <= COMMENT_CHAR_LIMIT) {
-                  current += chunk;
-                  continue;
-                }
-
-                flush();
-
-                if (chunk.length + continued.length <= COMMENT_CHAR_LIMIT) {
-                  current += chunk;
-                  continue;
-                }
-
-                // Chunk is too large even alone. Split it on line boundaries so the fenced
-                // block stays coherent, reopening the fence in each continuation.
-                const notice = '\n```\n\n**Note**: output exceeds the maximum comment size, continued in the next comment.';
-                const reopen = continued + '```diff\n';
-                const budget = COMMENT_CHAR_LIMIT - reopen.length - notice.length;
-
-                let buffer = '';
-                for (const line of chunk.split('\n')) {
-                  if (buffer.length + line.length + 1 > budget) {
-                    comments.push(current + buffer + notice);
-                    current = reopen;
-                    buffer = '';
+                if (chunk.kind === 'text') {
+                  if (hasContent && current.length + chunk.body.length > COMMENT_CHAR_LIMIT) {
+                    flush();
                   }
-                  buffer += line + '\n';
+                  append(chunk.body);
+                  continue;
                 }
-                current += buffer;
+
+                // Overhead is measured with the continuation suffix and the note present, so it
+                // is the worst case and can never under-reserve.
+                const overhead = renderDiffPart(chunk.entry, '', true, false).length;
+                const lines = chunk.diff.replace(/\n+$/, '').split('\n');
+
+                let index = 0;
+                let isContinuation = false;
+
+                while (index < lines.length) {
+                  const available = COMMENT_CHAR_LIMIT - current.length - overhead;
+
+                  // Too little room left to make useful progress; start a fresh comment
+                  if (available < 1024 && hasContent) {
+                    flush();
+                    continue;
+                  }
+
+                  const taken = [];
+                  let used = 0;
+                  while (index < lines.length && used + lines[index].length + 1 <= available) {
+                    used += lines[index].length + 1;
+                    taken.push(lines[index]);
+                    index += 1;
+                  }
+
+                  // A single line longer than a whole comment. Truncate it rather than loop
+                  // forever, and say so.
+                  if (taken.length === 0) {
+                    taken.push(`${lines[index].slice(0, Math.max(1, available - 64))} [line truncated]`);
+                    index += 1;
+                  }
+
+                  const isFinal = index >= lines.length;
+                  append(renderDiffPart(chunk.entry, taken.join('\n'), isContinuation, isFinal));
+                  isContinuation = true;
+
+                  if (!isFinal) flush();
+                }
               }
 
               flush();
@@ -463,15 +493,17 @@ jobs:
             const chunks = [];
 
             for (const { entry, message } of failed) {
-              chunks.push(
-                `### \`${entry.chart}\` / \`${entry.config}\`\n\n` +
+              chunks.push({
+                kind: 'text',
+                body:
+                  `### \`${entry.chart}\` / \`${entry.config}\`\n\n` +
                   `Could not produce a diff for this config.\n\n\`\`\`\n${message.trim()}\n\`\`\`\n\n`,
-              );
+              });
             }
 
             for (const item of changed) {
-              chunks.push(renderSummary(item.entry, item.parsed));
-              chunks.push(renderDiffBlock(item.entry, item.diff));
+              chunks.push({ kind: 'text', body: renderSummary(item.entry, item.parsed) });
+              chunks.push({ kind: 'diff', entry: item.entry, diff: item.diff });
             }
 
             for (const body of packComments(header, chunks)) {

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -64,6 +64,21 @@ jobs:
           mkdir -p shared/${MATRIX_REF_NAME}-charts
           if [ -f "${MATRIX_CHART}/Chart.yaml" ]; then
             helm dependency update "${MATRIX_CHART}"
+
+            # Render under the chart's own name rather than letting helm fall back to its
+            # `release-name` default. Charts using the stock `fullname` helper prefix resources
+            # with the release name, so the default produces names like
+            # `release-name-lando-web`, which match neither production nor a mozcloud chart
+            # naming resources from `app_code`. Because the diff matches resources on
+            # apiVersion/kind/metadata.name, a mismatched release name makes every resource
+            # look deleted and re-added. Mirrors `render-diff`, which defaults the release name
+            # to the chart name.
+            release_name=$(helm show chart "${MATRIX_CHART}" | sed -nE 's/^name:[[:space:]]*["'"'"']?([^"'"'"'[:space:]]+)["'"'"']?[[:space:]]*$/\1/p' | head -1)
+            if [ -z "$release_name" ]; then
+              release_name=$(basename "${MATRIX_CHART}")
+              echo "Could not read chart name from ${MATRIX_CHART}/Chart.yaml, falling back to ${release_name}"
+            fi
+
             values_files=$(find "$MATRIX_CHART" -maxdepth 1 -type f \( -name '*values*.yaml' -o -name '*values*.yml' \) ! \( -name 'values.yaml' -o -name 'values.yml' \))
 
             for values_path in ${values_files}; do
@@ -77,14 +92,14 @@ jobs:
 
               if [[ -n "$region" && -f "${MATRIX_CHART}/values-${env}.yaml" ]]; then
                 # Render with three layers: base, env, env-region
-                helm template "${MATRIX_CHART}" \
+                helm template "${release_name}" "${MATRIX_CHART}" \
                   -f "${MATRIX_CHART}/values.yaml" \
                   -f "${MATRIX_CHART}/values-${env}.yaml" \
                   -f "${MATRIX_CHART}/${values_file}" \
                   --output-dir "$render_path"
               else
                 # Only base + environment file
-                helm template "${MATRIX_CHART}" \
+                helm template "${release_name}" "${MATRIX_CHART}" \
                   -f "${MATRIX_CHART}/values.yaml" \
                   -f "${MATRIX_CHART}/${values_file}" \
                   --output-dir "$render_path"

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -65,19 +65,22 @@ jobs:
           if [ -f "${MATRIX_CHART}/Chart.yaml" ]; then
             helm dependency update "${MATRIX_CHART}"
 
-            # Render under the chart's own name rather than letting helm fall back to its
+            # Render under the chart directory's name rather than letting helm fall back to its
             # `release-name` default. Charts using the stock `fullname` helper prefix resources
-            # with the release name, so the default produces names like
-            # `release-name-lando-web`, which match neither production nor a mozcloud chart
-            # naming resources from `app_code`. Because the diff matches resources on
-            # apiVersion/kind/metadata.name, a mismatched release name makes every resource
-            # look deleted and re-added. Mirrors `render-diff`, which defaults the release name
-            # to the chart name.
-            release_name=$(helm show chart "${MATRIX_CHART}" | sed -nE 's/^name:[[:space:]]*["'"'"']?([^"'"'"'[:space:]]+)["'"'"']?[[:space:]]*$/\1/p' | head -1)
-            if [ -z "$release_name" ]; then
-              release_name=$(basename "${MATRIX_CHART}")
-              echo "Could not read chart name from ${MATRIX_CHART}/Chart.yaml, falling back to ${release_name}"
-            fi
+            # with the release name, so the default produces names like `release-name-lando-web`,
+            # which match neither production nor a mozcloud chart naming resources from
+            # `app_code`. Because the diff matches resources on apiVersion/kind/metadata.name, a
+            # mismatched release name makes every resource look deleted and re-added.
+            #
+            # The directory name is what Argo CD uses by default: the ApplicationSet sets
+            # `releaseName` from its `$chartName`, which is the chart's directory under
+            # `<app_code>/k8s/`. This also matches how validate-k8s-manifests.yml renders.
+            # Deliberately not the `name` field from Chart.yaml, which differs from the
+            # directory for a handful of charts and is not what Argo uses.
+            #
+            # Charts with a `release_name` override in their tenant config are not handled;
+            # those live in another repository and are not visible here.
+            release_name=$(basename "${MATRIX_CHART}")
 
             values_files=$(find "$MATRIX_CHART" -maxdepth 1 -type f \( -name '*values*.yaml' -o -name '*values*.yml' \) ! \( -name 'values.yaml' -o -name 'values.yml' \))
 

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -303,10 +303,12 @@ jobs:
                 resource.isRemoval =
                   resource.blocks.some(isRoot) && details.some((d) => /one document removed/.test(d));
 
-                // Re-emit each block with its path, minus the now redundant `# resource` line
+                // Re-emit each block with its path, minus the now redundant `# resource` line.
+                // Blocks are separated by a blank line so that consecutive changed fields do not
+                // run together into one wall of text.
                 resource.diff = resource.blocks
                   .map((b) => [`@@ ${b.path} @@`, ...b.lines].join('\n'))
-                  .join('\n');
+                  .join('\n\n');
               }
 
               return resources;

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -217,7 +217,6 @@ jobs:
             const fs = require('fs');
 
             const COMMENT_CHAR_LIMIT = 65536; // GitHub comment character limit
-            const MAX_LISTED_RESOURCES = 25;  // per category, before collapsing to a count
             // Identifies our own comments so superseded ones can be folded away on the next push
             const MARKER = '<!-- mozilla/deploy-actions:diff-rendered-charts -->';
             const INDEX_FILE = 'diff/index.tsv';

--- a/.github/workflows/diff-rendered-charts.yml
+++ b/.github/workflows/diff-rendered-charts.yml
@@ -256,55 +256,61 @@ jobs:
             //   ! <description of the change>
             //   +/- <values>
             //
+            // dyff emits these in document order, so every block for a resource is already
+            // contiguous. Only the hierarchy is inverted for a reader: each block leads with the
+            // field path and names the resource underneath, so one Deployment reads as a dozen
+            // unrelated blocks. Group them so the resource is the heading instead, which is how
+            // Argo CD presents a diff.
+            //
             // A path of `(root level)` paired with a document added/removed description means the
             // resource as a whole appeared or disappeared; anything else is a field-level change.
             function parseDyff(text) {
-              const resources = new Map();
-              let changeCount = 0;
-              let currentPath = null;
-              let currentResource = null;
+              const blocks = [];
+              let current = null;
 
               for (const line of text.split('\n')) {
-                const pathMatch = line.match(/^@@ (.*) @@$/);
-                const resourceMatch = line.match(/^# (.+)$/);
-                const detailMatch = line.match(/^! (.+)$/);
+                const path = line.match(/^@@ (.*) @@$/);
+                const resource = line.match(/^# (.+)$/);
 
-                if (pathMatch) {
-                  currentPath = pathMatch[1];
-                  currentResource = null;
-                  changeCount += 1;
-                } else if (resourceMatch && currentPath !== null) {
-                  currentResource = resourceMatch[1];
-                  if (!resources.has(currentResource)) {
-                    resources.set(currentResource, { added: false, removed: false });
-                  }
-                } else if (detailMatch && currentResource !== null) {
-                  const isRootLevel = currentPath === '(root level)';
-                  if (isRootLevel && /one document added/.test(detailMatch[1])) {
-                    resources.get(currentResource).added = true;
-                  }
-                  if (isRootLevel && /one document removed/.test(detailMatch[1])) {
-                    resources.get(currentResource).removed = true;
-                  }
+                if (path) {
+                  current = { path: path[1], id: null, lines: [] };
+                  blocks.push(current);
+                } else if (!current) {
+                  continue;
+                } else if (resource && current.id === null) {
+                  current.id = resource[1];
+                } else if (line.length > 0) {
+                  current.lines.push(line);
                 }
               }
 
-              const added = [];
-              const removed = [];
-              const updated = [];
-              for (const [id, flags] of resources) {
-                if (flags.added) added.push(id);
-                else if (flags.removed) removed.push(id);
-                else updated.push(id);
+              const resources = [];
+              for (const block of blocks) {
+                const last = resources[resources.length - 1];
+                if (last && last.id === block.id) {
+                  last.blocks.push(block);
+                } else {
+                  resources.push({ id: block.id, blocks: [block] });
+                }
               }
 
-              return {
-                changeCount,
-                resourceCount: resources.size,
-                added: added.sort(),
-                removed: removed.sort(),
-                updated: updated.sort(),
-              };
+              for (const resource of resources) {
+                const details = resource.blocks.flatMap((b) => b.lines.filter((l) => l.startsWith('!')));
+                const isRoot = (b) => b.path === '(root level)';
+
+                resource.changeCount = resource.blocks.length;
+                resource.isAddition =
+                  resource.blocks.some(isRoot) && details.some((d) => /one document added/.test(d));
+                resource.isRemoval =
+                  resource.blocks.some(isRoot) && details.some((d) => /one document removed/.test(d));
+
+                // Re-emit each block with its path, minus the now redundant `# resource` line
+                resource.diff = resource.blocks
+                  .map((b) => [`@@ ${b.path} @@`, ...b.lines].join('\n'))
+                  .join('\n');
+              }
+
+              return resources;
             }
 
             // A release-name mismatch between the two sides shows up as resources appearing in
@@ -314,15 +320,15 @@ jobs:
             // sets `release_name` renders under something else in production. Those overrides
             // live in another repository and are not visible here, so detect the symptom and say
             // so rather than presenting a wholesale replacement as if it were real.
-            function detectPrefixMismatch(parsed) {
+            function detectPrefixMismatch(resources) {
               const groupOf = (id) => id.split('/').slice(0, -1).join('/'); // apiVersion/Kind
               const nameOf = (id) => id.split('/').pop();
 
               const addedByGroup = new Map();
-              for (const id of parsed.added) {
-                const group = groupOf(id);
+              for (const r of resources.filter((r) => r.isAddition)) {
+                const group = groupOf(r.id);
                 if (!addedByGroup.has(group)) addedByGroup.set(group, []);
-                addedByGroup.get(group).push(nameOf(id));
+                addedByGroup.get(group).push(nameOf(r.id));
               }
 
               // Length of the shared trailing run of `-` separated segments. Comparing segments
@@ -338,9 +344,9 @@ jobs:
               };
 
               const deltas = new Map();
-              for (const id of parsed.removed) {
-                const removed = nameOf(id).split('-');
-                for (const addedName of addedByGroup.get(groupOf(id)) || []) {
+              for (const r of resources.filter((r) => r.isRemoval)) {
+                const removed = nameOf(r.id).split('-');
+                for (const addedName of addedByGroup.get(groupOf(r.id)) || []) {
                   const added = addedName.split('-');
                   const shared = sharedTail(removed, added);
 
@@ -371,37 +377,32 @@ jobs:
             // keys on dyff's own wording ("one document added"), so if that wording ever changes
             // every resource would quietly fall into Updated and the summary would mislead while
             // still looking plausible. This turns that silent drift into a warning.
-            function checkDocumentCounts(entry, parsed) {
+            function checkDocumentCounts(entry, resources) {
               const recorded = Number(entry.headDocs) - Number(entry.baseDocs);
-              const classified = parsed.added.length - parsed.removed.length;
+              const classified =
+                resources.filter((r) => r.isAddition).length -
+                resources.filter((r) => r.isRemoval).length;
 
               if (Number.isFinite(recorded) && recorded !== classified) {
                 core.warning(
                   `${entry.chart} / ${entry.config}: rendered document count changed by ` +
-                    `${recorded}, but ${parsed.added.length} added and ${parsed.removed.length} ` +
-                    `removed account for ${classified}. The added/removed/updated summary may be ` +
+                    `${recorded}, but the diff accounts for ${classified}. The summary may be ` +
                     `inaccurate; the diff itself is unaffected.`,
                 );
               }
             }
 
-            function renderResourceList(label, ids) {
-              if (ids.length === 0) return '';
+            // The per-config heading. The resources themselves follow as collapsible sections
+            // grouped under Updated / Added / Removed, rather than being listed by name here and
+            // then again below: naming each resource twice made the comment longer and forced the
+            // name list to be truncated on large diffs.
+            function renderSummary(entry, resources, mismatch) {
+              const changes = resources.reduce((n, r) => n + r.changeCount, 0);
 
-              const shown = ids.slice(0, MAX_LISTED_RESOURCES);
-              const lines = shown.map((id) => `- \`${id}\``);
-              if (ids.length > shown.length) {
-                lines.push(`- ...and ${ids.length - shown.length} more`);
-              }
-
-              return `**${label} (${ids.length})**\n${lines.join('\n')}\n\n`;
-            }
-
-            function renderSummary(entry, parsed, mismatch) {
               let body = `### \`${entry.chart}\` / \`${entry.config}\`\n\n`;
-              body += `**${parsed.changeCount} ${parsed.changeCount === 1 ? 'change' : 'changes'}`;
-              body += ` across ${parsed.resourceCount}`;
-              body += ` ${parsed.resourceCount === 1 ? 'resource' : 'resources'}**`;
+              body += `**${changes} ${changes === 1 ? 'change' : 'changes'}`;
+              body += ` across ${resources.length}`;
+              body += ` ${resources.length === 1 ? 'resource' : 'resources'}**`;
               body += ` (${entry.baseDocs} → ${entry.headDocs} documents)\n\n`;
 
               if (mismatch) {
@@ -414,23 +415,30 @@ jobs:
                 body += `unless the tenant config sets \`release_name\`. Migrated charts often name `;
                 body += `resources with the release name baked in, to avoid recreating them, so a chart `;
                 body += `with such an override will diff against a prefix it never uses in production. `;
-                body += `Treat the added and removed lists as one set of resources, not two.\n\n`;
+                body += `Treat the added and removed sections as one set of resources, not two.\n\n`;
               }
 
-              body += renderResourceList('Updated', parsed.updated);
-              body += renderResourceList('Added', parsed.added);
-              body += renderResourceList('Removed', parsed.removed);
               return body;
             }
 
-            // Render one slice of a diff, wrapped so that every comment is independently valid:
-            // its own <details> opened and closed, and its own fence opened and closed. An
-            // earlier version reopened only the fence in continuations, which left one comment
-            // with an unclosed <details> and the next with an orphan </details> rendered fully
-            // expanded.
-            function renderDiffPart(entry, body, isContinuation, isFinal) {
+            function renderCategoryHeading(label, count) {
+              return `**${label} (${count})**\n\n`;
+            }
+
+            // Render one slice of a resource's diff. Each resource is its own collapsible section
+            // so a reviewer expands only what they care about, and every section is independently
+            // valid: its own <details> opened and closed, its own fence opened and closed. That
+            // matters because a comment can end mid-resource.
+            function renderDiffPart(resource, body, isContinuation, isFinal) {
               const suffix = isContinuation ? ' (continued)' : '';
-              let out = `<details><summary>Show full diff for <code>${entry.chart}</code> / <code>${entry.config}</code>${suffix}</summary>\n\n`;
+              const n = resource.changeCount;
+              const detail = resource.isAddition
+                ? 'added'
+                : resource.isRemoval
+                  ? 'removed'
+                  : `${n} ${n === 1 ? 'change' : 'changes'}`;
+
+              let out = `<details><summary><code>${resource.id}</code> — ${detail}${suffix}</summary>\n\n`;
               out += '```diff\n' + body.replace(/\n+$/, '') + '\n```\n</details>\n\n';
               if (!isFinal) {
                 out += '**Note**: output exceeds the maximum comment size, continued in the next comment.\n\n';
@@ -470,8 +478,8 @@ jobs:
 
                 // Overhead is measured with the continuation suffix and the note present, so it
                 // is the worst case and can never under-reserve.
-                const overhead = renderDiffPart(chunk.entry, '', true, false).length;
-                const lines = chunk.diff.replace(/\n+$/, '').split('\n');
+                const overhead = renderDiffPart(chunk.resource, '', true, false).length;
+                const lines = chunk.resource.diff.replace(/\n+$/, '').split('\n');
 
                 let index = 0;
                 let isContinuation = false;
@@ -501,7 +509,7 @@ jobs:
                   }
 
                   const isFinal = index >= lines.length;
-                  append(renderDiffPart(chunk.entry, taken.join('\n'), isContinuation, isFinal));
+                  append(renderDiffPart(chunk.resource, taken.join('\n'), isContinuation, isFinal));
                   isContinuation = true;
 
                   if (!isFinal) flush();
@@ -551,10 +559,10 @@ jobs:
               if (diff.startsWith('DYFF_ERROR')) {
                 failed.push({ entry, message: diff.replace(/^DYFF_ERROR\n?/, '') });
               } else if (diff.trim().length > 0) {
-                const parsed = parseDyff(diff);
-                checkDocumentCounts(entry, parsed);
+                const resources = parseDyff(diff);
+                checkDocumentCounts(entry, resources);
 
-                const mismatch = detectPrefixMismatch(parsed);
+                const mismatch = detectPrefixMismatch(resources);
                 if (mismatch) {
                   core.warning(
                     `${entry.chart} / ${entry.config}: ${mismatch.count} resources differ only in ` +
@@ -564,7 +572,7 @@ jobs:
                   );
                 }
 
-                changed.push({ entry, diff, parsed, mismatch });
+                changed.push({ entry, resources, mismatch });
               } else {
                 unchanged.push(entry);
               }
@@ -605,8 +613,21 @@ jobs:
             }
 
             for (const item of changed) {
-              chunks.push({ kind: 'text', body: renderSummary(item.entry, item.parsed, item.mismatch) });
-              chunks.push({ kind: 'diff', entry: item.entry, diff: item.diff });
+              chunks.push({ kind: 'text', body: renderSummary(item.entry, item.resources, item.mismatch) });
+
+              const categories = [
+                ['Updated', item.resources.filter((r) => !r.isAddition && !r.isRemoval)],
+                ['Added', item.resources.filter((r) => r.isAddition)],
+                ['Removed', item.resources.filter((r) => r.isRemoval)],
+              ];
+
+              for (const [label, resources] of categories) {
+                if (resources.length === 0) continue;
+                chunks.push({ kind: 'text', body: renderCategoryHeading(label, resources.length) });
+                for (const resource of resources) {
+                  chunks.push({ kind: 'diff', resource });
+                }
+              }
             }
 
             for (const body of packComments(header, chunks)) {

--- a/.github/workflows/docs/diff-rendered-charts.md
+++ b/.github/workflows/docs/diff-rendered-charts.md
@@ -87,9 +87,24 @@ When a config renders identically on both sides it is called out as unchanged ra
 
 If the comment would exceed GitHub's 65536 character limit it is split across several comments, with the summary kept in the first.
 
+## How the manifests are assembled
+
+`render_charts` renders each chart once per values file, then concatenates that config's output into a single multi-document YAML beside the render directory:
+
+```
+shared/<ref>-charts/<chart>/<config>/     # helm template --output-dir tree
+shared/<ref>-charts/<chart>/<config>.yaml # the same manifests concatenated
+```
+
+Both the diff and the automerge evaluation read the `.yaml` file rather than walking the tree themselves. Building it once means the two cannot disagree about what was compared, and the work is not repeated.
+
+Charts are rendered under their **directory name** as the Helm release name, which is what Argo CD uses by default. This matters because the comparison matches resources by name: a release name that differs between the two sides makes every resource appear deleted and re-added. Charts whose tenant config overrides `release_name` are not handled, and the diff flags the symptom when it sees it (see MZCLD-3823).
+
+Concatenation order is irrelevant, since both consumers match documents on resource identity rather than position.
+
 ## Automerge evaluation
 
-With `automerge_test: true`, a separate job compares the same rendered manifests with [diffnest](https://github.com/sters/diffnest) to produce a JSON-patch representation of the change, then runs [conftest](https://www.conftest.dev/) against [`helm-automerge.rego`](https://github.com/mozilla/helm-charts/blob/main/policy/helm-automerge.rego) and reports the result as a `conftest test` commit status.
+With `automerge_test: true`, a separate job compares the same concatenated manifests with [diffnest](https://github.com/sters/diffnest) to produce a JSON-patch representation of the change, then runs [conftest](https://www.conftest.dev/) against [`helm-automerge.rego`](https://github.com/mozilla/helm-charts/blob/main/policy/helm-automerge.rego) and reports the result as a `conftest test` commit status.
 
 diffnest is used here rather than dyff because the policy consumes JSON-patch operations and dyff's CLI has no machine-readable output format. The policy only passes when the sole change is to the `mozcloud_chart_version` label, so anything else fails closed.
 

--- a/.github/workflows/docs/diff-rendered-charts.md
+++ b/.github/workflows/docs/diff-rendered-charts.md
@@ -1,12 +1,24 @@
 # Render and Diff Helm Charts Reusable Workflow
 
-Renders Helm charts from both the base and head refs of a pull request and posts a diff as a PR comment showing what changes will be deployed.
+Renders Helm charts from both the base and head refs of a pull request and posts a semantic diff as a PR comment showing what changes will be deployed.
 
 ## Overview
 
 - Detects changed Helm charts in pull requests
 - Renders charts with all values files (supports multi-layer configurations)
-- Posts a unified diff as a PR comment
+- Compares the rendered manifests with [dyff](https://github.com/homeport/dyff), which matches resources on `apiVersion`, `kind`, and `metadata.name`
+- Posts a per-resource summary with the full diff in a collapsible block
+- Folds away diff comments from previous pushes so only the current one is expanded
+
+## Why a semantic diff
+
+Rendered manifests used to be compared with `diff -ruN` over the two output directories, which makes a template's **filename** the de facto identity of a resource. Moving a template to a new path was therefore reported as an entire resource being deleted and an unrelated one being added, even when nothing about the resource actually changed.
+
+That is the normal shape of a MozCloud chart migration, where templates move from `chart/templates/*.yaml` to `chart/charts/mozcloud/templates/**.yaml`. Because most or all templates move at once, the old output was close to useless for review.
+
+dyff keys documents on `apiVersion`/`kind`/`metadata.name`, so resources are matched across path moves and the diff shows only the fields that actually changed. It also ignores list ordering and whitespace-only differences.
+
+For the same behavior locally, `render-diff --semantic` (from [mozilla/mozcloud](https://github.com/mozilla/mozcloud)) wraps the same dyff comparison.
 
 ## Usage
 
@@ -22,22 +34,69 @@ on:
 
 jobs:
   diff-charts:
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     uses: mozilla/deploy-actions/.github/workflows/diff-rendered-charts.yml@main
 ```
 
+`pull-requests: write` is required both to post the comment and to minimize superseded ones.
+
+## Inputs
+
+| Name | Description | Type | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `automerge_test` | Run conftest against the Helm diff output to evaluate if the PR is safe to automerge | boolean | no | `false` |
+
 ## Example Output
 
-When changes are detected, a comment will be posted to the PR:
+When changes are detected, a comment is posted to the PR:
 
-```diff
-Changes found in Helm charts.
+> ## Helm chart diff
+>
+> Rendered manifests compared by resource identity (`apiVersion`, `kind`, `metadata.name`), so resources are matched even when templates move to new paths.
+>
+> ### `lando/k8s/lando` / `values-dev`
+>
+> **142 changes across 44 resources** (36 → 41 documents)
+>
+> **Updated (25)**
+> - `apps/v1/Deployment/lando-web`
+> - `v1/ServiceAccount/lando`
+> - ...
+>
+> **Added (12)**
+> - `v1/Service/lando-web-headless`
+> - ...
+>
+> <details><summary>Show full diff for <code>lando/k8s/lando</code> / <code>values-dev</code></summary>
+>
+> ```diff
+> @@ metadata.annotations.argocd.argoproj.io/sync-wave @@
+> # v1/ServiceAccount/lando
+> ! ± value change in multiline text (one insert, one deletion)
+> - -3
+> + -11
+> ```
+> </details>
 
-Changes found in chart: apps/my-service/k8s
---- shared/base-charts/apps/my-service/k8s/values-prod/my-service/templates/deployment.yaml
-+++ shared/head-charts/apps/my-service/k8s/values-prod/my-service/templates/deployment.yaml
-@@ -15,7 +15,7 @@
-       containers:
-       - name: my-service
--        image: my-service:v1.0.0
-+        image: my-service:v1.1.0
-```
+Each entry in the full diff is a change block: the path that changed, the resource it belongs to (`# apiVersion/Kind/name`), a description of the change, and the values.
+
+When a config renders identically on both sides it is called out as unchanged rather than omitted silently, so a migration that is intentionally a no-op is visible as one.
+
+If the comment would exceed GitHub's 65536 character limit it is split across several comments, with the summary kept in the first.
+
+## Automerge evaluation
+
+With `automerge_test: true`, a separate job compares the same rendered manifests with [diffnest](https://github.com/sters/diffnest) to produce a JSON-patch representation of the change, then runs [conftest](https://www.conftest.dev/) against [`helm-automerge.rego`](https://github.com/mozilla/helm-charts/blob/main/policy/helm-automerge.rego) and reports the result as a `conftest test` commit status.
+
+diffnest is used here rather than dyff because the policy consumes JSON-patch operations and dyff's CLI has no machine-readable output format. The policy only passes when the sole change is to the `mozcloud_chart_version` label, so anything else fails closed.
+
+## Tool versions
+
+| Tool | Version | Used by |
+| :--- | :--- | :--- |
+| dyff | `v1.12.0` | `diff_helm_charts` |
+| diffnest | `v1.7.0` | `evaulate_helm_chart_automerge` |
+| conftest | `v0.68.2` | `evaulate_helm_chart_automerge` |


### PR DESCRIPTION
## Description

The `diff_helm_charts` job compared rendered charts by walking the two output trees with `diff -ruN`, which makes a template's **filename** the de facto identity of a resource. Moving a template to a new path was therefore reported as an entire resource being deleted and an unrelated one being added, even when nothing about the resource changed. That is the normal shape of a MozCloud chart migration, where templates move from `chart/templates/*.yaml` to `chart/charts/mozcloud/templates/**.yaml`, and because most or all templates move at once the comments were close to useless for review at exactly the point where careful review matters most.

This swaps the comparison to [dyff](https://github.com/homeport/dyff), which keys documents on `apiVersion`, `kind`, and `metadata.name`. Measured against a real migration (the lando dev chart), the old output ran to **109,117 characters across two comments**, nearly all of it wholesale additions and deletions. The new output is **43,765 characters in a single comment**, showing only the fields that actually changed.

Changes:
  - Diff each rendered config with `dyff` rather than `diff -ruN` over file trees
    - Runs per chart **and per config**; concatenating configs together would place duplicate resource identities (the same Deployment name across dev/stage/prod) in one document set and defeat identity matching
    - Ignores list ordering and whitespace-only differences
    - A `dyff` failure is surfaced in the comment rather than failing the job or being silently swallowed as "no changes"
  - Lead the comment with a per-resource summary above a collapsible full diff
    - Groups resources as Updated, Added, or Removed, keyed by identity
    - Names configs that rendered identically, so an intentional no-op reads as one rather than merely being absent
    - Warns when the added/removed classification fails to reconcile with the change in rendered document count, which would mean the parser has drifted from `dyff`'s output format
    - A chart that rendered nothing now warns instead of reporting "no changes", which would claim the manifests are identical when none were produced
  - Fold superseded diff comments on each new push, as the Atlantis bot does
    - Uses the `minimizeComment` GraphQL mutation with the `OUTDATED` classifier, matched on a hidden marker so unrelated comments are left alone
    - Every comment in a run carries the marker and its own balanced `<details>`, so a diff spanning several comments folds completely and each part renders collapsed
    - Failure to minimize degrades to a warning and never blocks posting the new comment
  - Render each chart under its directory name instead of helm's `release-name` default
    - `helm template` was called with no release name, so charts using the stock `fullname` helper produced identities like `release-name-lando-web` on the base side while a mozcloud chart naming resources from `app_code` produced `lando-web`. Harmless under filename-based diffing, fatal to identity matching
    - The directory name is what Argo CD uses by default, and matches how `validate-k8s-manifests.yml` already rendered
    - Charts whose tenant config overrides `release_name` are still rendered under the directory name; the diff detects and flags the symptom, and MZCLD-3823 covers the real fix
  - Warn when the two sides appear to have used different release names
    - Resources appearing as both added and removed with names differing only in their leading `-` separated segments are flagged in the comment and job log, naming the delta, for example `treeherder -> treeherder-v2`
    - Segment comparison rather than string suffix matching, since a release name is usually substituted rather than prepended
  - Concatenate the rendered manifests once, in `render_charts`, instead of twice in each consumer
    - Both the diff and the automerge evaluation now read the same `<config>.yaml`, so they cannot disagree about what was compared
    - Configs are enumerated with `find -exec basename` rather than piping to `xargs`. GNU xargs runs its command even on empty input, so a chart that rendered nothing invoked `basename` with no operands and failed the step under `set -euo pipefail`
    - Closes MZCLD-3821 and MZCLD-3822
  - Update `.github/workflows/docs/diff-rendered-charts.md`

### Effect on the automerge path

`evaulate_helm_chart_automerge` still uses `diffnest`, and deliberately so. The [`helm-automerge.rego`](https://github.com/mozilla/helm-charts/blob/main/policy/helm-automerge.rego) policy consumes JSON-patch operations (`input.op`, `input.path`), and `dyff`'s CLI has no machine-readable output format (`human`, `brief`, `github`, `gitlab`, `gitea` only), so `diffnest -format json-patch` remains the only option there.

The job is not untouched, though. It no longer concatenates manifests itself, and it shares `render_charts` with the diff, so its inputs changed. That was verified rather than argued: the evaluation was forced to run on a real chart pull request, where the `structured diff` step succeeded and `conftest` produced **477 tests, 477 failures**, exactly the count predicted from local analysis of the same manifests. Same input, same verdict, and it still fails closed on a change that is not a version bump. A synthetic version-bump-only input passes.

Separately, that exercise turned up a pre-existing gap in the policy itself: it allowed the chart version label to change only at the top level, not the copy the charts write into pod templates, so bumps on any chart with a workload never qualified for automerge. Fixed in mozilla/helm-charts#304, which is independent of this pull request.

### Example: a resource that moved files

`v1/ServiceAccount/lando` moved from `lando/templates/serviceaccount.yaml` to `lando/charts/mozcloud/templates/serviceaccount/serviceaccount.yaml`. Its only real changes are nine added labels and `sync-wave` going `-3` to `-11`; the two annotation keys were also reordered.

`diff -ruN` reports 39 lines as two unrelated blocks (a 20-line addition and an 11-line deletion) with nothing linking them. `dyff` reports 13 lines in two blocks, both keyed to `v1/ServiceAccount/lando`:

```diff
@@ metadata.annotations.argocd.argoproj.io/sync-wave @@
# v1/ServiceAccount/lando
! ± value change in multiline text (one insert, one deletion)
- -3
+ -11

@@ metadata.labels @@
# v1/ServiceAccount/lando
! + nine map entries added:
+ app.kubernetes.io/component: serviceaccount
...
```

The annotation reordering produces no output and the unchanged `iam.gke.io` value stays silent.

### Testing

This repo contains no Helm charts, so its own CI cannot exercise the change. It was verified locally and then end to end against a real chart pull request, mozilla/webservices-infra#12180.

Verified in CI on a real migration:

- The corrected diff: 142 changes across 44 resources, reported as 25 updated, 12 added and 7 removed in a single comment
- Configs that rendered identically (`values-stage`, `values-prod`) named as unchanged
- Multi-comment spillover, on a throwaway pull request with the size limit lowered: seven comments posted, each carrying the marker with balanced `<details>` and fences, and after a second push **all seven from the first run folded as outdated** while the new seven stayed current
- The automerge evaluation, forced on: `structured diff` succeeded and `conftest` returned the predicted 477 failures

Verified locally, running the **actual step bodies extracted from the workflow** rather than a hand-written approximation:

- 11 scenarios through the comment step: normal, no changes, `dyff` failure, multi-config, oversized, single-oversized (in-chunk splitting), missing index, both directions of the document-count invariant, and a second push folding a previous run's own multi-comment output. Every comment body within the 65536 limit, worst cases within a few bytes of the ceiling, all with balanced `<details>` and fences
- The release-name mismatch detector against four shapes taken from real tenant configs (`gha`, `treeherder-v2`, `outgoing-stage`, `yttest`) plus the authentic pre-fix output, with no false positive on a correct render
- The centralised concatenation, by deleting the manifests and confirming the diff step then produces nothing, proving it no longer builds them
- `dyff` and `diffnest` compared head to head, including an adversarial identity test (a resource renamed in place with its spec made byte-identical to a sibling, and document order swapped) to confirm neither relies on value-similarity matching
- `zizmor` reports no findings; `actionlint` shellcheck findings are fewer than on `main` (13 versus 16)

Worth recording that the first end-to-end run found the release-name bug, which local testing had missed because the original harness passed a release name where CI passed none. The harness now extracts the render and diff steps straight from the workflow and supplies only what CI supplies, so it cannot drift that way again. The document-count invariant did not catch that bug either: 36 to 41 documents is +5 and 35 added minus 30 removed is also +5, so it reconciled and stayed silent. It validates arithmetic, not whether a rename was classified correctly.

### Note for reviewers

`feat` cuts a minor release, and consumers pin a tag (`webservices-infra` is on `@v6.7.0`), so nothing picks this up until that pin moves.

## Related Tickets & Documents
* MZCLD-3077
* MZCLD-3096 (closed as a duplicate, consolidated into MZCLD-3077)
* MZCLD-3821 (fixed here)
* MZCLD-3822 (fixed here)
* MZCLD-3823 (follow-up: how the workflow should learn a chart's release name)
